### PR TITLE
fix(ci): 指定 Rust 1.86.0 支持 Cargo.lock v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Compile and release
-        uses: rust-build/rust-build.action@latest
+        uses: rust-build/rust-build.action@v1.4.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUSTTARGET: ${{ matrix.target }}
           ARCHIVE_TYPES: ${{ matrix.archive }}
+          TOOLCHAIN_VERSION: 1.86.0


### PR DESCRIPTION
## 问题

Release action 构建失败，错误: lock file version 4 was found, but this version of Cargo does not understand this lock file

## 原因

Cargo.lock v4 是 Rust 1.85 引入的新格式，但 rust-build action 默认 Rust 版本太旧

## 修复

添加 TOOLCHAIN_VERSION: 1.86.0 环境变量指定 Rust 版本，并固定 action 版本为 v1.4.5