### PR TITLE
fix: correct tuple format in documentation

### DIFF
--- a/docs/en/data-value.md
+++ b/docs/en/data-value.md
@@ -99,9 +99,9 @@ A tuple is an `array` that can only hold two pieces of data:
 
 ```
 ("LiuYuKun", 18)
-("SongHaoXin": 18)
-("XuGuanSen": 17)
-("ZhouQiXiang": 17)
+("SongHaoXin", 18)
+("XuGuanSen", 17)
+("ZhouQiXiang", 17)
 ```
 
 You can nest any data type inside, including nesting a new tuple.

--- a/docs/zh-cn/data-value.md
+++ b/docs/zh-cn/data-value.md
@@ -99,9 +99,9 @@ binary!(
 
 ```
 ("LiuYuKun", 18)
-("SongHaoXin": 18)
-("XuGuanSen": 17)
-("ZhouQiXiang": 17)
+("SongHaoXin", 18)
+("XuGuanSen", 17)
+("ZhouQiXiang", 17)
 ```
 
 你可以在里面嵌套任何数据类型，包括嵌套一个新的元组。


### PR DESCRIPTION
## 修复内容

### 问题
文档中元组格式不一致，第一个元素使用逗号分隔，但后面三个元素错误地使用了冒号分隔。

### 修改
- 修复中文文档 docs/zh-cn/data-value.md 中元组格式
- 修复英文文档 docs/en/data-value.md 中元组格式

### 变更对比
```diff
-("SongHaoXin": 18)
+("SongHaoXin", 18)
```

元组应统一使用逗号 , 作为分隔符。