### PR TITLE
fix: CLI SET command quote handling

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -859,17 +859,8 @@ pub async fn execute(command: &str, client: &mut DoreaClient) -> (NetPacketState
             }
         }
         "SET" => {
-            if parts.len() < 2 {
-                return (
-                    NetPacketState::ERR,
-                    "Usage: SET <key> <value> [expire]".into(),
-                );
-            }
-            let key = parts[0];
-            let value = parts[1..].join(" ");
-            // 直接发送原始命令给服务器
-            let command = format!("set {} {}", key, value);
-            match client.execute(&command).await {
+            // 直接发送原始命令给服务器，不分割重组，保留引号结构
+            match client.execute(command).await {
                 Ok((state, data)) => {
                     let result = String::from_utf8_lossy(&data).to_string();
                     (state, result)


### PR DESCRIPTION
## 问题描述

CLI 对 SET 命令使用 `split_whitespace()` + `join()` 处理，破坏了原始引号结构。

## 修复内容

- SET 命令直接透传原始输入给服务器
- 让 `parse_command_args` 统一处理引号解析
- 移除不必要的分割重组逻辑

## 测试

```bash
# 用户输入
set baz "\"1231321231\""

# Bash 解析后传给 CLI
set baz "1231321231"

# CLI 直接发送给服务器
set baz "1231321231"

# 服务器 parse_command_args 解析
value = "1231321231"
```