### PR TITLE
feat(cli): add TUI mode for data browsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## v0.5.0
 
+### 🖥️ TUI 模式
+
+- **新增 TUI (Terminal User Interface) 模式**：通过 `dorea-cli tui` 命令或 REPL 中输入 `tui` 启动
+- **Tab 切换界面**：Data / Monitor / Log / Help 四个 Tab，支持 `Tab` / `Shift+Tab` 切换
+- **Data Tab**：两列布局（键列表 | 值视图），支持 Vim 风格导航 (`j`/`k`/`h`/`l`) 和方向键
+- **Pretty 模式**：组件化值展示，支持 Dict/List/Tuple 展开折叠，语法高亮（String 绿色、Number 黄色、Boolean 紫色）
+- **智能展开**：第一层子项 ≤30 时自动展开，超过则折叠
+- **Monitor Tab**：显示服务器版本、运行时间、连接数、索引数等信息，切换 Tab 时自动刷新
+- **Log Tab**：记录操作日志
+- **命令输入**：按 `:` 进入命令模式，执行结果以居中弹窗显示，支持 ESC 关闭、`:` 覆盖
+- **快捷键**：`r` 刷新、`F2` 切换 Pretty/Raw、`Enter` 展开/折叠、`q` 退出
+
 ### 🚀 性能优化
 
 - **Pipeline 批量写入**：新增 `DoreaClient::pipeline()` 方法，支持批量发送命令，吞吐量提升 **2.28x**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +182,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,7 +232,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags 1.3.2",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -249,6 +270,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +312,31 @@ name = "crc-catalog"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.13.0",
+ "crossterm_winapi",
+ "mio 1.2.1",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-common"
@@ -338,6 +398,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
  "quote",
  "syn 2.0.15",
 ]
@@ -444,6 +538,7 @@ dependencies = [
  "clap",
  "colored",
  "crc",
+ "crossterm",
  "ctrlc",
  "dashmap",
  "dirs",
@@ -459,6 +554,7 @@ dependencies = [
  "nom",
  "once_cell",
  "rand",
+ "ratatui",
  "rustyline",
  "serde",
  "serde_json",
@@ -483,6 +579,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +598,22 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "error-code"
@@ -522,6 +640,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -674,6 +798,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
 name = "headers"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +832,12 @@ checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -811,6 +952,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +975,37 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -867,9 +1045,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "link-cplusplus"
@@ -885,6 +1063,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "lock_api"
@@ -938,6 +1122,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "matchit"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,6 +1170,18 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1125,6 +1330,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pem"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,9 +1392,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1235,6 +1446,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "strum_macros",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1295,6 +1527,25 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustyline"
@@ -1448,6 +1699,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 1.2.1",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1521,6 +1793,34 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.15",
+]
 
 [[package]]
 name = "syn"
@@ -1634,7 +1934,7 @@ dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "mio",
+ "mio 0.8.6",
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
@@ -1827,10 +2127,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
+name = "unicode-truncate"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unsafe-any-ors"
@@ -2052,6 +2363,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,6 +2411,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,6 +2437,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2106,6 +2457,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,6 +2473,18 @@ name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2130,6 +2499,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2140,6 +2515,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2154,6 +2535,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2164,6 +2551,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ server = [
 ]
 
 # client features: client manager tools.
-client = ["processor"]
+client = ["processor", "ratatui", "crossterm"]
 
 # processor feature: include [value, network] to io data and fmt it.
 processor = []
@@ -98,6 +98,10 @@ rand = "0.8"
 
 # Terminal Colors
 colored = "2.1"
+
+# TUI Framework (optional, for client feature)
+ratatui = { version = "0.28", optional = true }
+crossterm = { version = "0.28", optional = true }
 
 # Logger Library
 log = "0.4.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dorea"
-version = "0.4.0"
+version = "0.5.0"
 description = "A key-value storage system"
 repository = "https://github.com/mrxiaozhuox/dorea/"
 authors = ["YuKun Liu <mrxzx.info@gmail.com>"]

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -14,6 +14,11 @@ use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::process::exit;
 
+// TUI 模块
+#[cfg(feature = "client")]
+#[path = "../cli_tui.rs"]
+mod cli_tui;
+
 const DOREA_CLI_VERSION: &str = "0.5.0";
 
 /// 打印启动 Banner
@@ -719,6 +724,31 @@ pub async fn main() {
                         .default_value("default"),
                 ),
         )
+        .subcommand(
+            SubCommand::with_name("tui")
+                .about("Start TUI mode (Terminal User Interface)")
+                .arg(
+                    Arg::with_name("HOSTNAME")
+                        .short("h")
+                        .long("hostname")
+                        .takes_value(true)
+                        .default_value("127.0.0.1"),
+                )
+                .arg(
+                    Arg::with_name("PORT")
+                        .short("p")
+                        .long("port")
+                        .takes_value(true)
+                        .default_value("3450"),
+                )
+                .arg(
+                    Arg::with_name("PASSWORD")
+                        .short("a")
+                        .long("password")
+                        .takes_value(true)
+                        .default_value(""),
+                ),
+        )
         .get_matches();
 
     // 单次执行模式
@@ -753,6 +783,36 @@ pub async fn main() {
             print_err(&res.1);
         } else {
             smart_format(&res.1);
+        }
+        return;
+    }
+
+    // TUI 模式
+    if let Some(m) = matches.subcommand_matches("tui") {
+        let hostname = m.value_of("HOSTNAME").unwrap();
+        let port = m.value_of("PORT").unwrap();
+        let password = m.value_of("PASSWORD").unwrap();
+
+        let client = DoreaClient::connect(
+            (
+                Box::leak(hostname.to_string().into_boxed_str()),
+                port.parse::<u16>().unwrap_or(3450),
+            ),
+            password,
+        )
+        .await;
+
+        match client {
+            Ok(c) => {
+                if let Err(e) = cli_tui::run_tui(c, hostname.to_string(), port.parse().unwrap_or(3450)).await {
+                    eprintln!("TUI error: {:?}", e);
+                    exit(1);
+                }
+            }
+            Err(e) => {
+                print_err(&format!("Connection failed: {:?}", e));
+                exit(1);
+            }
         }
         return;
     }
@@ -799,6 +859,40 @@ pub async fn main() {
                 if cmd == "exit" || cmd == "quit" {
                     println!("\n  {} Bye! 👋\n", "✓".green().bold());
                     exit(0);
+                }
+                if cmd == "tui" {
+                    // 进入 TUI 模式（需要重新创建连接，因为 DoreaClient 不支持 Clone）
+                    println!("\n  {} Entering TUI mode...\n", "✓".green().bold());
+                    
+                    // 重新连接
+                    let tui_client = DoreaClient::connect(
+                        (
+                            Box::leak(hostname.to_string().into_boxed_str()),
+                            port.parse::<u16>().unwrap_or(3450),
+                        ),
+                        password,
+                    ).await;
+                    
+                    match tui_client {
+                        Ok(c) => {
+                            if let Err(e) = cli_tui::run_tui(c, hostname.to_string(), port.parse().unwrap_or(3450)).await {
+                                println!("  {} TUI error: {:?}\n", "✗".red().bold(), e);
+                            }
+                        }
+                        Err(e) => {
+                            println!("  {} Connection failed: {:?}\n", "✗".red().bold(), e);
+                        }
+                    }
+                    
+                    // TUI 退出后重新显示 banner
+                    print_banner();
+                    println!(
+                        "  {} Connected to {}:{}\n",
+                        "✓".green().bold(),
+                        hostname.white().bold(),
+                        port.white().bold()
+                    );
+                    continue;
                 }
                 if cmd.is_empty() {
                     continue;

--- a/src/cli_tui.rs
+++ b/src/cli_tui.rs
@@ -60,7 +60,6 @@ impl TabId {
 /// 面板焦点
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum Focus {
-    DatabaseList,
     KeyList,
     ValueView,
     CommandInput,
@@ -86,10 +85,6 @@ pub struct App {
     hostname: String,
     port: u16,
     current_database: String,
-    
-    // 数据库列表
-    databases: Vec<String>,
-    selected_database: usize,
     
     // 键列表
     keys: Vec<KeyInfo>,
@@ -151,13 +146,11 @@ impl App {
     pub fn new(hostname: String, port: u16) -> Self {
         Self {
             current_tab: TabId::Data,
-            focus: Focus::DatabaseList,
+            focus: Focus::KeyList,
             value_mode: ValueViewMode::Tree,
             hostname,
             port,
             current_database: "default".to_string(),
-            databases: vec!["default".to_string()],
-            selected_database: 0,
             keys: Vec::new(),
             selected_key: 0,
             key_scroll_offset: 0,
@@ -305,84 +298,38 @@ async fn handle_data_tab_keys(
     match key.code {
         // 导航 - 支持 j/k 和 上下方向键
         KeyCode::Char('j') | KeyCode::Down => {
-            match app.focus {
-                Focus::DatabaseList => {
-                    if app.selected_database < app.databases.len() - 1 {
-                        app.selected_database += 1;
-                    }
+            if app.selected_key < app.keys.len().saturating_sub(1) {
+                app.selected_key += 1;
+                // 加载值 - 先 clone key 避免借用冲突
+                let key = app.keys.get(app.selected_key).map(|k| k.key.clone());
+                if let Some(key) = key {
+                    load_key_value(app, client, &key).await;
                 }
-                Focus::KeyList => {
-                    if app.selected_key < app.keys.len().saturating_sub(1) {
-                        app.selected_key += 1;
-                        // 加载值 - 先 clone key 避免借用冲突
-                        let key = app.keys.get(app.selected_key).map(|k| k.key.clone());
-                        if let Some(key) = key {
-                            load_key_value(app, client, &key).await;
-                        }
-                    }
-                }
-                _ => {}
             }
         }
         KeyCode::Char('k') | KeyCode::Up => {
-            match app.focus {
-                Focus::DatabaseList => {
-                    if app.selected_database > 0 {
-                        app.selected_database -= 1;
-                    }
+            if app.selected_key > 0 {
+                app.selected_key -= 1;
+                let key = app.keys.get(app.selected_key).map(|k| k.key.clone());
+                if let Some(key) = key {
+                    load_key_value(app, client, &key).await;
                 }
-                Focus::KeyList => {
-                    if app.selected_key > 0 {
-                        app.selected_key -= 1;
-                        let key = app.keys.get(app.selected_key).map(|k| k.key.clone());
-                        if let Some(key) = key {
-                            load_key_value(app, client, &key).await;
-                        }
-                    }
-                }
-                _ => {}
             }
         }
         // 支持 h/l 和 左右方向键
         KeyCode::Char('h') | KeyCode::Left => {
-            match app.focus {
-                Focus::KeyList => app.focus = Focus::DatabaseList,
-                Focus::ValueView => app.focus = Focus::KeyList,
-                _ => {}
+            if app.focus == Focus::ValueView {
+                app.focus = Focus::KeyList;
             }
         }
         KeyCode::Char('l') | KeyCode::Right => {
-            match app.focus {
-                Focus::DatabaseList => app.focus = Focus::KeyList,
-                Focus::KeyList => app.focus = Focus::ValueView,
-                _ => {}
+            if app.focus == Focus::KeyList {
+                app.focus = Focus::ValueView;
             }
         }
         KeyCode::Char('G') => {
-            if app.focus == Focus::KeyList && !app.keys.is_empty() {
+            if !app.keys.is_empty() {
                 app.selected_key = app.keys.len() - 1;
-            }
-        }
-        KeyCode::Enter => {
-            if app.focus == Focus::DatabaseList {
-                // 切换数据库
-                if let Some(db) = app.databases.get(app.selected_database) {
-                    let db_name = db.clone();
-                    match client.select(&db_name).await {
-                        Ok(_) => {
-                            app.current_database = db_name.clone();
-                            app.keys.clear();
-                            app.selected_key = 0;
-                            app.current_value = None;
-                            app.add_log("INFO", &format!("Switched to database: {}", db_name));
-                            // 加载键列表
-                            load_keys(app, client).await;
-                        }
-                        Err(e) => {
-                            app.add_log("ERROR", &format!("Failed to switch database: {:?}", e));
-                        }
-                    }
-                }
             }
         }
         KeyCode::Char('r') => {
@@ -750,42 +697,13 @@ fn ui(f: &mut Frame, app: &mut App) {
 
 /// 渲染 Data Tab
 fn render_data_tab(f: &mut Frame, app: &mut App, area: Rect) {
+    // 两列布局：键列表 | 值视图
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Length(20), Constraint::Min(40)])
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
         .split(area);
     
-    // 左侧：数据库列表
-    let db_items: Vec<ListItem> = app
-        .databases
-        .iter()
-        .enumerate()
-        .map(|(i, db)| {
-            let style = if i == app.selected_database && app.focus == Focus::DatabaseList {
-                Style::default().fg(Color::Yellow).bg(Color::DarkGray)
-            } else if i == app.selected_database {
-                Style::default().fg(Color::Yellow)
-            } else {
-                Style::default().fg(Color::White)
-            };
-            ListItem::new(Line::from(Span::styled(format!("  {}", db), style)))
-        })
-        .collect();
-    
-    let db_list = List::new(db_items)
-        .block(Block::default()
-            .borders(Borders::ALL)
-            .title(" Databases ")
-            .title_style(Style::default().fg(Color::Cyan)));
-    f.render_widget(db_list, chunks[0]);
-    
-    // 右侧：键列表 + 值视图
-    let right_chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-        .split(chunks[1]);
-    
-    // 键列表
+    // 左侧：键列表
     let key_rows: Vec<Row> = app
         .keys
         .iter()
@@ -819,9 +737,9 @@ fn render_data_tab(f: &mut Frame, app: &mut App, area: Rect) {
         .borders(Borders::ALL)
         .title(format!(" Keys ({}) ", app.keys.len()))
         .title_style(Style::default().fg(Color::Cyan)));
-    f.render_widget(key_table, right_chunks[0]);
+    f.render_widget(key_table, chunks[0]);
     
-    // 值视图
+    // 右侧：值视图
     let value_title = if let Some(ref vtype) = app.current_value_type {
         format!(" Value ({}) ", vtype)
     } else {
@@ -843,7 +761,7 @@ fn render_data_tab(f: &mut Frame, app: &mut App, area: Rect) {
             .borders(Borders::ALL)
             .title(value_title + mode_hint)
             .title_style(Style::default().fg(Color::Cyan)));
-    f.render_widget(value_widget, right_chunks[1]);
+    f.render_widget(value_widget, chunks[1]);
 }
 
 /// 渲染 Monitor Tab

--- a/src/cli_tui.rs
+++ b/src/cli_tui.rs
@@ -462,19 +462,28 @@ async fn load_key_value(app: &mut App, client: &mut DoreaClient, key: &str) {
     match client.execute(&command).await {
         Ok((state, data)) if state == NetPacketState::OK => {
             let raw_value = String::from_utf8_lossy(&data).to_string();
+            
+            // 检查是否为空或 key 不存在
+            if raw_value.is_empty() {
+                app.current_value = Some("(key not found)".to_string());
+                app.current_value_raw = None;
+                app.current_value_type = None;
+                return;
+            }
+            
             let value_type = infer_value_type(&raw_value);
             
             // 格式化值（Tree 模式）
             let formatted_value = format_value(&raw_value, &value_type);
             
-            app.current_value_raw = Some(raw_value);
+            app.current_value_raw = Some(raw_value.clone());
             app.current_value = Some(formatted_value);
             app.current_value_type = Some(value_type.clone());
             
             // 更新键列表中的类型
             if let Some(key_info) = app.keys.iter_mut().find(|k| k.key == key) {
                 key_info.key_type = value_type;
-                key_info.size = format!("{}B", app.current_value_raw.as_ref().unwrap().len());
+                key_info.size = format!("{}B", raw_value.len());
             }
         }
         _ => {

--- a/src/cli_tui.rs
+++ b/src/cli_tui.rs
@@ -72,6 +72,25 @@ enum ValueViewMode {
     Raw,
 }
 
+/// 值树节点（用于 Pretty 模式的组件化渲染）
+#[derive(Debug, Clone)]
+enum ValueNode {
+    String(String),
+    Number(String),
+    Boolean(bool),
+    Null,
+    Array(Vec<ValueNode>),
+    Object(Vec<(String, ValueNode)>),
+}
+
+/// 展开状态
+#[derive(Debug, Clone, Default)]
+struct ExpandState {
+    expanded: std::collections::HashSet<String>,
+    cursor_path: String,  // 当前光标所在路径
+    scroll_offset: usize, // 值树滚动偏移
+}
+
 /// TUI 应用状态
 pub struct App {
     /// 当前 Tab
@@ -95,6 +114,10 @@ pub struct App {
     current_value: Option<String>,
     current_value_raw: Option<String>,
     current_value_type: Option<String>,
+    
+    // 值树（Pretty 模式用）
+    value_tree: Option<ValueNode>,
+    expand_state: ExpandState,
     
     // 命令输入
     command_input: String,
@@ -159,6 +182,8 @@ impl App {
             current_value: None,
             current_value_raw: None,
             current_value_type: None,
+            value_tree: None,
+            expand_state: ExpandState::default(),
             command_input: String::new(),
             command_mode: false,
             command_result: None,
@@ -356,6 +381,17 @@ async fn handle_data_tab_keys(
                 ValueViewMode::Raw => ValueViewMode::Pretty,
             };
         }
+        // Enter 键展开/折叠值树节点
+        KeyCode::Enter => {
+            if app.focus == Focus::ValueView && app.value_mode == ValueViewMode::Pretty {
+                // 切换根节点展开状态
+                if app.expand_state.expanded.contains("") {
+                    app.expand_state.expanded.remove("");
+                } else {
+                    app.expand_state.expanded.insert("".to_string());
+                }
+            }
+        }
         _ => {}
     }
     
@@ -475,12 +511,17 @@ async fn load_key_value(app: &mut App, client: &mut DoreaClient, key: &str) {
             
             let value_type = infer_value_type(&raw_value);
             
-            // 格式化值（Pretty 模式）
-            let formatted_value = format_value(&raw_value, &value_type);
+            // 解析值树（用于 Pretty 模式的组件化渲染）
+            let value_tree = parse_value_to_tree(&raw_value);
+            
+            // 格式化值（作为备用的简单文本）
+            let formatted_value = format_value_simple(&raw_value, &value_type);
             
             app.current_value_raw = Some(raw_value.clone());
             app.current_value = Some(formatted_value);
             app.current_value_type = Some(value_type.clone());
+            app.value_tree = value_tree;
+            app.expand_state = ExpandState::default();  // 重置展开状态
             
             // 更新键列表中的类型
             if let Some(key_info) = app.keys.iter_mut().find(|k| k.key == key) {
@@ -492,119 +533,197 @@ async fn load_key_value(app: &mut App, client: &mut DoreaClient, key: &str) {
             app.current_value = Some("(error loading value)".to_string());
             app.current_value_raw = None;
             app.current_value_type = None;
+            app.value_tree = None;
         }
     }
 }
 
-/// 格式化值（Pretty 模式）- 树形结构美化
-fn format_value(value: &str, value_type: &str) -> String {
-    match value_type {
-        "Dict" => format_dict_tree(value),
-        "List" => format_list_tree(value),
-        _ => value.to_string(),
+/// 解析 JSON 值为 ValueNode 树
+fn parse_value_to_tree(value: &str) -> Option<ValueNode> {
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(value) {
+        Some(json_to_node(&json))
+    } else {
+        None
     }
 }
 
-/// 格式化 Dict 为树形结构
-fn format_dict_tree(value: &str) -> String {
-    // 尝试解析为 JSON
-    if let Ok(json) = serde_json::from_str::<serde_json::Value>(value) {
-        if let serde_json::Value::Object(map) = json {
-            let mut result = String::new();
-            let keys: Vec<_> = map.keys().collect();
+/// JSON Value 转 ValueNode
+fn json_to_node(value: &serde_json::Value) -> ValueNode {
+    match value {
+        serde_json::Value::String(s) => ValueNode::String(s.clone()),
+        serde_json::Value::Number(n) => ValueNode::Number(n.to_string()),
+        serde_json::Value::Bool(b) => ValueNode::Boolean(*b),
+        serde_json::Value::Null => ValueNode::Null,
+        serde_json::Value::Array(arr) => {
+            ValueNode::Array(arr.iter().map(json_to_node).collect())
+        }
+        serde_json::Value::Object(map) => {
+            ValueNode::Object(
+                map.iter()
+                    .map(|(k, v)| (k.clone(), json_to_node(v)))
+                    .collect()
+            )
+        }
+    }
+}
+
+/// 渲染值树为可滚动的 Lines
+fn render_value_tree(node: &ValueNode, expand_state: &ExpandState) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    render_node(node, "", 0, true, expand_state, &mut lines);
+    if lines.is_empty() {
+        lines.push(Line::from("(empty)"));
+    }
+    lines
+}
+
+/// 递归渲染节点
+fn render_node(
+    node: &ValueNode,
+    path: &str,
+    depth: usize,
+    is_last: bool,
+    expand_state: &ExpandState,
+    lines: &mut Vec<Line<'static>>,
+) {
+    let indent = "  ".repeat(depth);
+    let prefix = if depth == 0 { "" } else if is_last { "└─" } else { "├─" };
+    
+    match node {
+        ValueNode::String(s) => {
+            let display = if s.len() > 50 {
+                format!("\"{}...\"", &s[..47])
+            } else {
+                format!("\"{}\"", s)
+            };
+            lines.push(Line::from(vec![
+                Span::raw(format!("{}{}", indent, prefix)),
+                Span::styled(display, Style::default().fg(Color::Green)),
+            ]));
+        }
+        ValueNode::Number(n) => {
+            lines.push(Line::from(vec![
+                Span::raw(format!("{}{}", indent, prefix)),
+                Span::styled(n.clone(), Style::default().fg(Color::Yellow)),
+            ]));
+        }
+        ValueNode::Boolean(b) => {
+            let text = if *b { "true" } else { "false" };
+            lines.push(Line::from(vec![
+                Span::raw(format!("{}{}", indent, prefix)),
+                Span::styled(text, Style::default().fg(Color::Magenta)),
+            ]));
+        }
+        ValueNode::Null => {
+            lines.push(Line::from(vec![
+                Span::raw(format!("{}{}", indent, prefix)),
+                Span::styled("null", Style::default().fg(Color::DarkGray)),
+            ]));
+        }
+        ValueNode::Array(arr) => {
+            let is_expanded = expand_state.expanded.contains(path);
+            let count = arr.len();
+            let icon = if is_expanded { "▼" } else { "▶" };
             
-            for (i, key) in keys.iter().enumerate() {
-                let is_last = i == keys.len() - 1;
-                let prefix = if is_last { "└── " } else { "├── " };
-                
-                if let Some(val) = map.get(*key) {
-                    result.push_str(&format!("{}{}: ", prefix, key));
-                    result.push_str(&format_json_value(val, if is_last { "    " } else { "│   " }));
-                    result.push('\n');
+            lines.push(Line::from(vec![
+                Span::raw(format!("{}{}", indent, prefix)),
+                Span::styled(format!("{} [{} items]", icon, count), Style::default().fg(Color::Cyan)),
+            ]));
+            
+            if is_expanded {
+                for (i, item) in arr.iter().enumerate() {
+                    let item_path = format!("{}[{}]", path, i);
+                    let item_is_last = i == arr.len() - 1;
+                    render_node(item, &item_path, depth + 1, item_is_last, expand_state, lines);
                 }
             }
-            
-            return result.trim_end().to_string();
         }
-    }
-    
-    // 解析失败，返回原始值
-    value.to_string()
-}
-
-/// 格式化 List 为树形结构
-fn format_list_tree(value: &str) -> String {
-    if let Ok(json) = serde_json::from_str::<serde_json::Value>(value) {
-        if let serde_json::Value::Array(arr) = json {
-            let mut result = String::new();
+        ValueNode::Object(map) => {
+            let is_expanded = expand_state.expanded.contains(path);
+            let count = map.len();
+            let icon = if is_expanded { "▼" } else { "▶" };
             
-            for (i, item) in arr.iter().enumerate() {
-                let is_last = i == arr.len() - 1;
-                let prefix = if is_last { "└── " } else { "├── " };
-                let indent = if is_last { "    " } else { "│   " };
-                
-                result.push_str(&format!("{}[{}] ", prefix, i));
-                result.push_str(&format_json_value(item, indent));
-                result.push('\n');
-            }
+            lines.push(Line::from(vec![
+                Span::raw(format!("{}{}", indent, prefix)),
+                Span::styled(format!("{} {{{}}} keys", icon, count), Style::default().fg(Color::Cyan)),
+            ]));
             
-            return result.trim_end().to_string();
-        }
-    }
-    
-    value.to_string()
-}
-
-/// 格式化 JSON 值（递归）
-fn format_json_value(value: &serde_json::Value, indent: &str) -> String {
-    match value {
-        serde_json::Value::Object(map) => {
-            if map.is_empty() {
-                "{}".to_string()
-            } else {
-                let mut result = "{\n".to_string();
-                let keys: Vec<_> = map.keys().collect();
-                
-                for (i, key) in keys.iter().enumerate() {
-                    let is_last = i == keys.len() - 1;
-                    let prefix = if is_last { "└── " } else { "├── " };
-                    let next_indent = if is_last { "    " } else { "│   " };
+            if is_expanded {
+                for (i, (key, value)) in map.iter().enumerate() {
+                    let item_path = format!("{}.{}", path, key);
+                    let item_is_last = i == map.len() - 1;
                     
-                    if let Some(val) = map.get(*key) {
-                        result.push_str(&format!("{}{}{}: ", indent, prefix, key));
-                        result.push_str(&format_json_value(val, &format!("{}{}", indent, next_indent)));
-                        result.push('\n');
+                    // 先渲染 key
+                    let key_indent = "  ".repeat(depth + 1);
+                    let key_prefix = if item_is_last { "└─" } else { "├─" };
+                    
+                    match value {
+                        ValueNode::String(s) => {
+                            let display = if s.len() > 40 {
+                                format!("\"{}...\"", &s[..37])
+                            } else {
+                                format!("\"{}\"", s)
+                            };
+                            lines.push(Line::from(vec![
+                                Span::raw(format!("{}{}", key_indent, key_prefix)),
+                                Span::styled(key.clone(), Style::default().fg(Color::Blue)),
+                                Span::raw(": "),
+                                Span::styled(display, Style::default().fg(Color::Green)),
+                            ]));
+                        }
+                        ValueNode::Number(n) => {
+                            lines.push(Line::from(vec![
+                                Span::raw(format!("{}{}", key_indent, key_prefix)),
+                                Span::styled(key.clone(), Style::default().fg(Color::Blue)),
+                                Span::raw(": "),
+                                Span::styled(n.clone(), Style::default().fg(Color::Yellow)),
+                            ]));
+                        }
+                        ValueNode::Boolean(b) => {
+                            let text = if *b { "true" } else { "false" };
+                            lines.push(Line::from(vec![
+                                Span::raw(format!("{}{}", key_indent, key_prefix)),
+                                Span::styled(key.clone(), Style::default().fg(Color::Blue)),
+                                Span::raw(": "),
+                                Span::styled(text, Style::default().fg(Color::Magenta)),
+                            ]));
+                        }
+                        ValueNode::Null => {
+                            lines.push(Line::from(vec![
+                                Span::raw(format!("{}{}", key_indent, key_prefix)),
+                                Span::styled(key.clone(), Style::default().fg(Color::Blue)),
+                                Span::raw(": "),
+                                Span::styled("null", Style::default().fg(Color::DarkGray)),
+                            ]));
+                        }
+                        _ => {
+                            // 复合类型，递归
+                            lines.push(Line::from(vec![
+                                Span::raw(format!("{}{}", key_indent, key_prefix)),
+                                Span::styled(key.clone(), Style::default().fg(Color::Blue)),
+                                Span::raw(": "),
+                            ]));
+                            render_node(value, &item_path, depth + 2, item_is_last, expand_state, lines);
+                        }
                     }
                 }
-                
-                result.push_str(&format!("{}}}", &indent[..indent.len().saturating_sub(4)]));
-                result
             }
         }
-        serde_json::Value::Array(arr) => {
-            if arr.is_empty() {
-                "[]".to_string()
+    }
+}
+
+/// 格式化值（Pretty 模式）- 简单文本美化（非 JSON）
+fn format_value_simple(value: &str, value_type: &str) -> String {
+    match value_type {
+        "Dict" | "List" | "Tuple" => {
+            // 尝试 JSON 美化
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(value) {
+                serde_json::to_string_pretty(&json).unwrap_or_else(|_| value.to_string())
             } else {
-                let mut result = "[\n".to_string();
-                
-                for (i, item) in arr.iter().enumerate() {
-                    let is_last = i == arr.len() - 1;
-                    let prefix = if is_last { "└── " } else { "├── " };
-                    let next_indent = if is_last { "    " } else { "│   " };
-                    
-                    result.push_str(&format!("{}{}[{}] ", indent, prefix, i));
-                    result.push_str(&format_json_value(item, &format!("{}{}", indent, next_indent)));
-                    result.push('\n');
-                }
-                
-                result.push_str(&format!("{}]", &indent[..indent.len().saturating_sub(4)]));
-                result
+                value.to_string()
             }
         }
-        serde_json::Value::String(s) => format!("\"{}\"", s),
-        serde_json::Value::Number(n) => n.to_string(),
-        serde_json::Value::Bool(b) => b.to_string(),
-        serde_json::Value::Null => "null".to_string(),
+        _ => value.to_string(),
     }
 }
 
@@ -938,23 +1057,39 @@ fn render_data_tab(f: &mut Frame, app: &mut App, area: Rect) {
     };
     
     // 根据模式选择显示的值
-    let value_content = match app.value_mode {
-        ValueViewMode::Pretty => match &app.current_value {
-            Some(value) => value.clone(),
-            None => "(no value)".to_string(),
-        },
-        ValueViewMode::Raw => match &app.current_value_raw {
-            Some(value) => value.clone(),
-            None => "(no value)".to_string(),
-        },
-    };
-    
-    let value_widget = Paragraph::new(value_content)
-        .block(Block::default()
-            .borders(Borders::ALL)
-            .title(value_title + mode_hint)
-            .title_style(Style::default().fg(Color::Cyan)));
-    f.render_widget(value_widget, chunks[1]);
+    match app.value_mode {
+        ValueViewMode::Pretty => {
+            // 使用组件化渲染
+            if let Some(tree) = &app.value_tree {
+                let lines = render_value_tree(tree, &app.expand_state);
+                let value_widget = Paragraph::new(lines)
+                    .block(Block::default()
+                        .borders(Borders::ALL)
+                        .title(value_title.clone() + mode_hint)
+                        .title_style(Style::default().fg(Color::Cyan)));
+                f.render_widget(value_widget, chunks[1]);
+            } else {
+                // 没有值树，显示简单文本
+                let text = app.current_value.as_deref().unwrap_or("(no value)");
+                let value_widget = Paragraph::new(text)
+                    .block(Block::default()
+                        .borders(Borders::ALL)
+                        .title(value_title.clone() + mode_hint)
+                        .title_style(Style::default().fg(Color::Cyan)));
+                f.render_widget(value_widget, chunks[1]);
+            }
+        }
+        ValueViewMode::Raw => {
+            // 显示原始值
+            let text = app.current_value_raw.as_deref().unwrap_or("(no value)");
+            let value_widget = Paragraph::new(text)
+                .block(Block::default()
+                    .borders(Borders::ALL)
+                    .title(value_title + mode_hint)
+                    .title_style(Style::default().fg(Color::Cyan)));
+            f.render_widget(value_widget, chunks[1]);
+        }
+    }
 }
 
 /// 渲染 Monitor Tab

--- a/src/cli_tui.rs
+++ b/src/cli_tui.rs
@@ -292,6 +292,13 @@ async fn handle_key_event(
         KeyCode::Char('q') => {
             app.should_quit = true;
         }
+        KeyCode::Esc => {
+            // ESC 关闭命令结果弹窗
+            if app.command_result.is_some() {
+                app.command_result = None;
+                app.command_result_time = None;
+            }
+        }
         KeyCode::Tab => {
             let prev_tab = app.current_tab;
             app.current_tab = app.current_tab.next();
@@ -319,6 +326,9 @@ async fn handle_key_event(
             }
         }
         KeyCode::Char(':') => {
+            // 关闭弹窗并打开命令输入
+            app.command_result = None;
+            app.command_result_time = None;
             app.command_mode = true;
             app.command_input.clear();
         }
@@ -1012,6 +1022,7 @@ fn ui(f: &mut Frame, app: &mut App) {
                     Span::styled(format!("{} ", icon), Style::default().fg(color).bold()),
                     Span::styled(msg, Style::default().fg(Color::White)),
                 ]))
+                .alignment(ratatui::layout::Alignment::Center)
                 .block(Block::default()
                     .borders(Borders::ALL)
                     .title(" Result ")

--- a/src/cli_tui.rs
+++ b/src/cli_tui.rs
@@ -134,8 +134,8 @@ struct MonitorData {
     uptime: String,
     connected_clients: String,
     total_keys: String,
-    memory_used: String,
-    total_commands: String,
+    total_indexes: String,
+    current_db: String,
     last_updated: String,
 }
 
@@ -483,7 +483,7 @@ fn parse_key_list(data: &str) -> Vec<KeyInfo> {
             if !key.is_empty() {
                 keys.push(KeyInfo {
                     key: key.clone(),
-                    key_type: "Unknown".to_string(),
+                    key_type: "-".to_string(),  // 未加载时显示 "-"
                     size: "-".to_string(),
                     ttl: "-".to_string(),
                 });
@@ -539,30 +539,32 @@ fn infer_value_type(value: &str) -> String {
 
 /// 加载 Monitor 数据
 async fn load_monitor_data(app: &mut App, client: &mut DoreaClient) {
-    // 获取服务器信息
-    if let Ok((state, data)) = client.execute("info server").await {
+    // 获取服务器版本 - 直接返回版本字符串
+    if let Ok((state, data)) = client.execute("info version").await {
         if state == NetPacketState::OK {
-            let info = String::from_utf8_lossy(&data).to_string();
-            // 解析服务器信息
-            for line in info.lines() {
-                if let Some(version) = line.strip_prefix("version:") {
-                    app.monitor.server_version = version.trim().to_string();
-                } else if let Some(uptime) = line.strip_prefix("uptime:") {
-                    app.monitor.uptime = format_seconds(uptime.trim().parse().unwrap_or(0));
-                }
+            let version = String::from_utf8_lossy(&data).to_string();
+            app.monitor.server_version = version.trim().trim_matches('"').to_string();
+        }
+    }
+    
+    // 获取服务器启动时间 - 返回时间戳字符串
+    if let Ok((state, data)) = client.execute("info server-startup-time").await {
+        if state == NetPacketState::OK {
+            let startup = String::from_utf8_lossy(&data).to_string();
+            // 尝试解析时间戳计算 uptime
+            if let Ok(ts) = startup.trim().parse::<i64>() {
+                let now = chrono::Utc::now().timestamp();
+                let uptime_secs = (now - ts).max(0) as u64;
+                app.monitor.uptime = format_seconds(uptime_secs);
             }
         }
     }
     
-    // 获取客户端连接数
-    if let Ok((state, data)) = client.execute("info client").await {
+    // 获取当前连接数
+    if let Ok((state, data)) = client.execute("info current-connect-num").await {
         if state == NetPacketState::OK {
-            let info = String::from_utf8_lossy(&data).to_string();
-            for line in info.lines() {
-                if let Some(count) = line.strip_prefix("connected:") {
-                    app.monitor.connected_clients = count.trim().to_string();
-                }
-            }
+            let count = String::from_utf8_lossy(&data).to_string();
+            app.monitor.connected_clients = count.trim().to_string();
         }
     }
     
@@ -578,15 +580,19 @@ async fn load_monitor_data(app: &mut App, client: &mut DoreaClient) {
         }
     }
     
-    // 获取内存使用
-    if let Ok((state, data)) = client.execute("info memory").await {
+    // 获取总索引数
+    if let Ok((state, data)) = client.execute("info total-index-number").await {
         if state == NetPacketState::OK {
-            let info = String::from_utf8_lossy(&data).to_string();
-            for line in info.lines() {
-                if let Some(memory) = line.strip_prefix("used:") {
-                    app.monitor.memory_used = format_bytes(memory.trim().parse().unwrap_or(0));
-                }
-            }
+            let count = String::from_utf8_lossy(&data).to_string();
+            app.monitor.total_indexes = count.trim().to_string();
+        }
+    }
+    
+    // 获取当前数据库
+    if let Ok((state, data)) = client.execute("info current").await {
+        if state == NetPacketState::OK {
+            let db = String::from_utf8_lossy(&data).to_string();
+            app.monitor.current_db = db.trim().trim_matches('"').to_string();
         }
     }
     
@@ -602,23 +608,6 @@ fn format_seconds(seconds: u64) -> String {
         format!("{}m {}s", seconds / 60, seconds % 60)
     } else {
         format!("{}h {}m", seconds / 3600, (seconds % 3600) / 60)
-    }
-}
-
-/// 格式化字节数为可读大小
-fn format_bytes(bytes: u64) -> String {
-    const KB: u64 = 1024;
-    const MB: u64 = KB * 1024;
-    const GB: u64 = MB * 1024;
-    
-    if bytes >= GB {
-        format!("{:.2} GB", bytes as f64 / GB as f64)
-    } else if bytes >= MB {
-        format!("{:.2} MB", bytes as f64 / MB as f64)
-    } else if bytes >= KB {
-        format!("{:.2} KB", bytes as f64 / KB as f64)
-    } else {
-        format!("{} B", bytes)
     }
 }
 
@@ -638,9 +627,11 @@ async fn execute_command(app: &mut App, client: &mut DoreaClient, cmd: &str) {
             match client.select(db).await {
                 Ok(_) => {
                     app.current_database = db.to_string();
+                    app.status_message = format!("✓ Switched to database: {}", db);
                     app.add_log("INFO", &format!("Switched to database: {}", db));
                 }
                 Err(e) => {
+                    app.status_message = format!("✗ Error: {:?}", e);
                     app.add_log("ERROR", &format!("Failed: {:?}", e));
                 }
             }
@@ -651,12 +642,24 @@ async fn execute_command(app: &mut App, client: &mut DoreaClient, cmd: &str) {
                 Ok((state, data)) => {
                     let result = String::from_utf8_lossy(&data).to_string();
                     if state == NetPacketState::OK {
-                        app.add_log("INFO", &format!("OK: {}", if result.len() > 50 { &result[..50] } else { &result }));
+                        let preview = if result.len() > 50 { 
+                            format!("{}...", &result[..47])
+                        } else { 
+                            result.clone()
+                        };
+                        app.status_message = format!("✓ {}", preview);
+                        app.add_log("INFO", &format!("OK: {}", preview));
+                        // 如果是 keys 相关命令，刷新键列表
+                        if cmd.starts_with("set ") || cmd.starts_with("delete ") {
+                            // 可选：自动刷新键列表
+                        }
                     } else {
+                        app.status_message = format!("✗ {}", result);
                         app.add_log("ERROR", &result);
                     }
                 }
                 Err(e) => {
+                    app.status_message = format!("✗ Error: {:?}", e);
                     app.add_log("ERROR", &format!("Error: {:?}", e));
                 }
             }
@@ -845,66 +848,125 @@ fn render_data_tab(f: &mut Frame, app: &mut App, area: Rect) {
 
 /// 渲染 Monitor Tab
 fn render_monitor_tab(f: &mut Frame, app: &mut App, area: Rect) {
-    // 使用两列布局
+    // 使用三行布局：顶部标题、中间信息、底部提示
     let chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),  // 标题行
+            Constraint::Min(10),    // 信息区
+            Constraint::Length(3),  // 提示行
+        ])
         .split(area);
     
+    // 顶部标题 - 显示连接信息和当前数据库
+    let title_text = format!(
+        " {}:{}  │  DB: {} ",
+        app.hostname,
+        app.port,
+        if app.monitor.current_db.is_empty() { &app.current_database } else { &app.monitor.current_db }
+    );
+    let title = Paragraph::new(title_text)
+        .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+        .alignment(ratatui::layout::Alignment::Center)
+        .block(Block::default().borders(Borders::ALL));
+    f.render_widget(title, chunks[0]);
+    
+    // 中间信息区 - 两列布局
+    let info_chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(chunks[1]);
+    
     // 左侧 - 服务器信息
+    let server_version = if app.monitor.server_version.is_empty() { "-" } else { &app.monitor.server_version };
+    let uptime = if app.monitor.uptime.is_empty() { "-" } else { &app.monitor.uptime };
+    let connected = if app.monitor.connected_clients.is_empty() { "-" } else { &app.monitor.connected_clients };
+    
     let server_info = vec![
+        Line::from(""),
         Line::from(vec![
-            Span::styled("Server Version:  ", Style::default().fg(Color::DarkGray)),
-            Span::styled(&app.monitor.server_version, Style::default().fg(Color::White)),
+            Span::styled("  ● ", Style::default().fg(Color::Green)),
+            Span::styled("Server Version", Style::default().fg(Color::DarkGray)),
+        ]),
+        Line::from(vec![
+            Span::raw("    "),
+            Span::styled(server_version, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
         ]),
         Line::from(""),
         Line::from(vec![
-            Span::styled("Uptime:          ", Style::default().fg(Color::DarkGray)),
-            Span::styled(&app.monitor.uptime, Style::default().fg(Color::White)),
+            Span::styled("  ⏱ ", Style::default().fg(Color::Yellow)),
+            Span::styled("Uptime", Style::default().fg(Color::DarkGray)),
         ]),
         Line::from(vec![
-            Span::styled("Connected:       ", Style::default().fg(Color::DarkGray)),
-            Span::styled(&app.monitor.connected_clients, Style::default().fg(Color::Green)),
+            Span::raw("    "),
+            Span::styled(uptime, Style::default().fg(Color::White)),
         ]),
         Line::from(""),
         Line::from(vec![
-            Span::styled("Last Updated:    ", Style::default().fg(Color::DarkGray)),
-            Span::styled(&app.monitor.last_updated, Style::default().fg(Color::Yellow)),
+            Span::styled("  ↻ ", Style::default().fg(Color::Cyan)),
+            Span::styled("Connections", Style::default().fg(Color::DarkGray)),
+        ]),
+        Line::from(vec![
+            Span::raw("    "),
+            Span::styled(connected, Style::default().fg(Color::Green)),
         ]),
     ];
     
     let left_panel = Paragraph::new(server_info)
         .block(Block::default()
             .borders(Borders::ALL)
-            .title(" Server Info ")
-            .title_style(Style::default().fg(Color::Cyan)));
-    f.render_widget(left_panel, chunks[0]);
+            .title(" Server ")
+            .title_style(Style::default().fg(Color::Yellow)));
+    f.render_widget(left_panel, info_chunks[0]);
     
     // 右侧 - 数据统计
+    let total_keys = if app.monitor.total_keys.is_empty() { "-" } else { &app.monitor.total_keys };
+    let total_indexes = if app.monitor.total_indexes.is_empty() { "-" } else { &app.monitor.total_indexes };
+    let last_updated = if app.monitor.last_updated.is_empty() { "-" } else { &app.monitor.last_updated };
+    
     let data_stats = vec![
+        Line::from(""),
         Line::from(vec![
-            Span::styled("Total Keys:      ", Style::default().fg(Color::DarkGray)),
-            Span::styled(&app.monitor.total_keys, Style::default().fg(Color::White)),
+            Span::styled("  🔑 ", Style::default().fg(Color::Magenta)),
+            Span::styled("Total Keys", Style::default().fg(Color::DarkGray)),
+        ]),
+        Line::from(vec![
+            Span::raw("    "),
+            Span::styled(total_keys, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
         ]),
         Line::from(""),
         Line::from(vec![
-            Span::styled("Memory Used:     ", Style::default().fg(Color::DarkGray)),
-            Span::styled(&app.monitor.memory_used, Style::default().fg(Color::Magenta)),
+            Span::styled("  📊 ", Style::default().fg(Color::Blue)),
+            Span::styled("Total Indexes", Style::default().fg(Color::DarkGray)),
         ]),
         Line::from(vec![
-            Span::styled("Total Commands:  ", Style::default().fg(Color::DarkGray)),
-            Span::styled(&app.monitor.total_commands, Style::default().fg(Color::White)),
+            Span::raw("    "),
+            Span::styled(total_indexes, Style::default().fg(Color::White)),
         ]),
         Line::from(""),
-        Line::from(Span::styled("Press r to refresh", Style::default().fg(Color::DarkGray))),
+        Line::from(vec![
+            Span::styled("  🕐 ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Last Update", Style::default().fg(Color::DarkGray)),
+        ]),
+        Line::from(vec![
+            Span::raw("    "),
+            Span::styled(last_updated, Style::default().fg(Color::Yellow)),
+        ]),
     ];
     
     let right_panel = Paragraph::new(data_stats)
         .block(Block::default()
             .borders(Borders::ALL)
-            .title(" Statistics ")
+            .title(" Stats ")
             .title_style(Style::default().fg(Color::Cyan)));
-    f.render_widget(right_panel, chunks[1]);
+    f.render_widget(right_panel, info_chunks[1]);
+    
+    // 底部提示
+    let hint = Paragraph::new(" Press [r] to refresh  │  [Tab] switch tab  │  [q] quit ")
+        .style(Style::default().fg(Color::DarkGray))
+        .alignment(ratatui::layout::Alignment::Center)
+        .block(Block::default().borders(Borders::ALL));
+    f.render_widget(hint, chunks[2]);
 }
 
 /// 渲染 Log Tab

--- a/src/cli_tui.rs
+++ b/src/cli_tui.rs
@@ -1,0 +1,844 @@
+// Dorea CLI TUI Mode
+// Terminal User Interface for Dorea Key-Value Storage System
+//
+// Author: YuKun Liu <mrxzx.info@gmail.com>
+
+use dorea::client::DoreaClient;
+use dorea::network::NetPacketState;
+use dorea::value::DataValue;
+use crossterm::{
+    event::{self, Event, KeyCode, KeyModifiers, KeyEventKind},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style, Stylize},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, Paragraph, Table, Row, Tabs, Clear},
+    Frame, Terminal,
+};
+use std::io;
+use std::time::Duration;
+
+const DOREA_CLI_VERSION: &str = "0.5.0";
+
+/// Tab 定义
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum TabId {
+    Data,
+    Monitor,
+    Log,
+    Help,
+}
+
+impl TabId {
+    fn titles() -> Vec<&'static str> {
+        vec!["Data", "Monitor", "Log", "Help"]
+    }
+    
+    fn next(self) -> Self {
+        match self {
+            TabId::Data => TabId::Monitor,
+            TabId::Monitor => TabId::Log,
+            TabId::Log => TabId::Help,
+            TabId::Help => TabId::Data,
+        }
+    }
+    
+    fn prev(self) -> Self {
+        match self {
+            TabId::Data => TabId::Help,
+            TabId::Monitor => TabId::Data,
+            TabId::Log => TabId::Monitor,
+            TabId::Help => TabId::Log,
+        }
+    }
+}
+
+/// 面板焦点
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum Focus {
+    DatabaseList,
+    KeyList,
+    ValueView,
+    CommandInput,
+}
+
+/// 值显示模式
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ValueViewMode {
+    Tree,
+    Raw,
+}
+
+/// TUI 应用状态
+pub struct App {
+    /// 当前 Tab
+    current_tab: TabId,
+    /// 当前焦点面板
+    focus: Focus,
+    /// 值显示模式
+    value_mode: ValueViewMode,
+    
+    // 连接信息
+    hostname: String,
+    port: u16,
+    current_database: String,
+    
+    // 数据库列表
+    databases: Vec<String>,
+    selected_database: usize,
+    
+    // 键列表
+    keys: Vec<KeyInfo>,
+    selected_key: usize,
+    key_scroll_offset: usize,
+    
+    // 当前值
+    current_value: Option<String>,
+    current_value_type: Option<String>,
+    
+    // 命令输入
+    command_input: String,
+    command_mode: bool,
+    command_result: Option<(bool, String)>,
+    
+    // 操作日志
+    logs: Vec<LogEntry>,
+    
+    // 状态消息
+    status_message: String,
+    
+    // 是否应该退出
+    should_quit: bool,
+}
+
+/// 键信息
+#[derive(Debug, Clone)]
+struct KeyInfo {
+    key: String,
+    key_type: String,
+    size: String,
+    ttl: String,
+}
+
+/// 日志条目
+#[derive(Debug, Clone)]
+struct LogEntry {
+    timestamp: String,
+    level: String,
+    message: String,
+}
+
+impl App {
+    pub fn new(hostname: String, port: u16) -> Self {
+        Self {
+            current_tab: TabId::Data,
+            focus: Focus::DatabaseList,
+            value_mode: ValueViewMode::Tree,
+            hostname,
+            port,
+            current_database: "default".to_string(),
+            databases: vec!["default".to_string()],
+            selected_database: 0,
+            keys: Vec::new(),
+            selected_key: 0,
+            key_scroll_offset: 0,
+            current_value: None,
+            current_value_type: None,
+            command_input: String::new(),
+            command_mode: false,
+            command_result: None,
+            logs: Vec::new(),
+            status_message: "Press j/k to navigate, h/l to switch panels, q to quit".to_string(),
+            should_quit: false,
+        }
+    }
+    
+    fn add_log(&mut self, level: &str, message: &str) {
+        let timestamp = chrono::Local::now().format("%H:%M:%S").to_string();
+        self.logs.push(LogEntry {
+            timestamp,
+            level: level.to_string(),
+            message: message.to_string(),
+        });
+        // 保持最近 100 条日志
+        if self.logs.len() > 100 {
+            self.logs.remove(0);
+        }
+    }
+}
+
+/// 运行 TUI 模式
+pub async fn run_tui(client: DoreaClient, hostname: String, port: u16) -> Result<(), Box<dyn std::error::Error>> {
+    // 设置终端
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+    
+    // 创建应用状态
+    let mut app = App::new(hostname, port);
+    let mut client = client;
+    
+    // 初始加载数据库列表
+    app.add_log("INFO", "Connected to server");
+    
+    // 主循环
+    loop {
+        // 绘制界面
+        terminal.draw(|f| ui(f, &mut app))?;
+        
+        // 处理事件
+        if event::poll(Duration::from_millis(100))? {
+            if let Event::Key(key) = event::read()? {
+                if key.kind == KeyEventKind::Press {
+                    handle_key_event(key, &mut app, &mut client).await?;
+                }
+            }
+        }
+        
+        if app.should_quit {
+            break;
+        }
+    }
+    
+    // 恢复终端
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    
+    Ok(())
+}
+
+/// 处理键盘事件
+async fn handle_key_event(
+    key: event::KeyEvent,
+    app: &mut App,
+    client: &mut DoreaClient,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // 命令输入模式
+    if app.command_mode {
+        match key.code {
+            KeyCode::Esc => {
+                app.command_mode = false;
+                app.command_input.clear();
+            }
+            KeyCode::Enter => {
+                // 执行命令
+                let cmd = app.command_input.trim().to_string();
+                if cmd == "q" || cmd == "quit" {
+                    app.should_quit = true;
+                } else {
+                    execute_command(app, client, &cmd).await;
+                }
+                app.command_mode = false;
+                app.command_input.clear();
+            }
+            KeyCode::Char(c) => {
+                app.command_input.push(c);
+            }
+            KeyCode::Backspace => {
+                app.command_input.pop();
+            }
+            _ => {}
+        }
+        return Ok(());
+    }
+    
+    // 全局快捷键
+    match key.code {
+        KeyCode::Char('q') => {
+            app.should_quit = true;
+        }
+        KeyCode::Tab => {
+            app.current_tab = app.current_tab.next();
+        }
+        KeyCode::Char('g') if key.modifiers.contains(KeyModifiers::NONE) => {
+            // gg = 跳转到顶部（需要两次 g）
+        }
+        KeyCode::Char('t') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.current_tab = app.current_tab.next();
+        }
+        KeyCode::Char(':') => {
+            app.command_mode = true;
+            app.command_input.clear();
+        }
+        _ => {
+            // Tab 特定快捷键
+            match app.current_tab {
+                TabId::Data => handle_data_tab_keys(key, app, client).await?,
+                TabId::Monitor => handle_monitor_tab_keys(key, app).await?,
+                TabId::Log => handle_log_tab_keys(key, app).await?,
+                TabId::Help => handle_help_tab_keys(key, app).await?,
+            }
+        }
+    }
+    
+    Ok(())
+}
+
+/// 处理 Data Tab 快捷键
+async fn handle_data_tab_keys(
+    key: event::KeyEvent,
+    app: &mut App,
+    client: &mut DoreaClient,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match key.code {
+        // 导航
+        KeyCode::Char('j') => {
+            match app.focus {
+                Focus::DatabaseList => {
+                    if app.selected_database < app.databases.len() - 1 {
+                        app.selected_database += 1;
+                    }
+                }
+                Focus::KeyList => {
+                    if app.selected_key < app.keys.len().saturating_sub(1) {
+                        app.selected_key += 1;
+                        // 加载值 - 先 clone key 避免借用冲突
+                        let key = app.keys.get(app.selected_key).map(|k| k.key.clone());
+                        if let Some(key) = key {
+                            load_key_value(app, client, &key).await;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        KeyCode::Char('k') => {
+            match app.focus {
+                Focus::DatabaseList => {
+                    if app.selected_database > 0 {
+                        app.selected_database -= 1;
+                    }
+                }
+                Focus::KeyList => {
+                    if app.selected_key > 0 {
+                        app.selected_key -= 1;
+                        let key = app.keys.get(app.selected_key).map(|k| k.key.clone());
+                        if let Some(key) = key {
+                            load_key_value(app, client, &key).await;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        KeyCode::Char('h') => {
+            match app.focus {
+                Focus::KeyList => app.focus = Focus::DatabaseList,
+                Focus::ValueView => app.focus = Focus::KeyList,
+                _ => {}
+            }
+        }
+        KeyCode::Char('l') => {
+            match app.focus {
+                Focus::DatabaseList => app.focus = Focus::KeyList,
+                Focus::KeyList => app.focus = Focus::ValueView,
+                _ => {}
+            }
+        }
+        KeyCode::Char('G') => {
+            if app.focus == Focus::KeyList && !app.keys.is_empty() {
+                app.selected_key = app.keys.len() - 1;
+            }
+        }
+        KeyCode::Enter => {
+            if app.focus == Focus::DatabaseList {
+                // 切换数据库
+                if let Some(db) = app.databases.get(app.selected_database) {
+                    let db_name = db.clone();
+                    match client.select(&db_name).await {
+                        Ok(_) => {
+                            app.current_database = db_name.clone();
+                            app.keys.clear();
+                            app.selected_key = 0;
+                            app.current_value = None;
+                            app.add_log("INFO", &format!("Switched to database: {}", db_name));
+                            // 加载键列表
+                            load_keys(app, client).await;
+                        }
+                        Err(e) => {
+                            app.add_log("ERROR", &format!("Failed to switch database: {:?}", e));
+                        }
+                    }
+                }
+            }
+        }
+        KeyCode::Char('r') => {
+            // 刷新
+            load_keys(app, client).await;
+            app.add_log("INFO", "Refreshed key list");
+        }
+        KeyCode::Char('/') => {
+            // TODO: 搜索
+            app.status_message = "Search: (not implemented yet)".to_string();
+        }
+        KeyCode::F(2) => {
+            // 切换 Tree/Raw 模式
+            app.value_mode = match app.value_mode {
+                ValueViewMode::Tree => ValueViewMode::Raw,
+                ValueViewMode::Raw => ValueViewMode::Tree,
+            };
+        }
+        _ => {}
+    }
+    
+    Ok(())
+}
+
+/// 处理 Monitor Tab 快捷键
+async fn handle_monitor_tab_keys(
+    key: event::KeyEvent,
+    app: &mut App,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match key.code {
+        KeyCode::Char('r') => {
+            app.add_log("INFO", "Refreshed monitor data");
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// 处理 Log Tab 快捷键
+async fn handle_log_tab_keys(
+    key: event::KeyEvent,
+    app: &mut App,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match key.code {
+        KeyCode::Char('j') => {
+            // 向下滚动
+        }
+        KeyCode::Char('k') => {
+            // 向上滚动
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// 处理 Help Tab 快捷键
+async fn handle_help_tab_keys(
+    key: event::KeyEvent,
+    app: &mut App,
+) -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
+}
+
+/// 加载键列表
+async fn load_keys(app: &mut App, client: &mut DoreaClient) {
+    match client.execute("info keys").await {
+        Ok((state, data)) if state == NetPacketState::OK => {
+            let result = String::from_utf8_lossy(&data).to_string();
+            // 解析键列表 ["key1", "key2", ...]
+            app.keys = parse_key_list(&result);
+            app.status_message = format!("Loaded {} keys", app.keys.len());
+            
+            // 加载第一个键的值 - 先 clone key 避免借用冲突
+            let first_key = app.keys.first().map(|k| k.key.clone());
+            if let Some(key) = first_key {
+                load_key_value(app, client, &key).await;
+            }
+        }
+        _ => {
+            app.keys.clear();
+            app.status_message = "Failed to load keys".to_string();
+        }
+    }
+}
+
+/// 解析键列表
+fn parse_key_list(data: &str) -> Vec<KeyInfo> {
+    let mut keys = Vec::new();
+    
+    // 简单解析 JSON 数组
+    let trimmed = data.trim();
+    if trimmed.starts_with('[') && trimmed.ends_with(']') {
+        let content = &trimmed[1..trimmed.len()-1];
+        for item in content.split(',') {
+            let key = item.trim().trim_matches('"').to_string();
+            if !key.is_empty() {
+                keys.push(KeyInfo {
+                    key: key.clone(),
+                    key_type: "Unknown".to_string(),
+                    size: "-".to_string(),
+                    ttl: "-".to_string(),
+                });
+            }
+        }
+    }
+    
+    keys
+}
+
+/// 加载键的值
+async fn load_key_value(app: &mut App, client: &mut DoreaClient, key: &str) {
+    let command = format!("get {}", key);
+    match client.execute(&command).await {
+        Ok((state, data)) if state == NetPacketState::OK => {
+            let value = String::from_utf8_lossy(&data).to_string();
+            app.current_value = Some(value);
+            // 尝试推断类型
+            app.current_value_type = Some(infer_value_type(&app.current_value.as_ref().unwrap()));
+        }
+        _ => {
+            app.current_value = Some("(error loading value)".to_string());
+            app.current_value_type = None;
+        }
+    }
+}
+
+/// 推断值类型
+fn infer_value_type(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.starts_with('{') && trimmed.ends_with('}') {
+        "Dict".to_string()
+    } else if trimmed.starts_with('[') && trimmed.ends_with(']') {
+        "List".to_string()
+    } else if trimmed.starts_with('(') && trimmed.ends_with(')') {
+        "Tuple".to_string()
+    } else if trimmed.starts_with('"') && trimmed.ends_with('"') {
+        "String".to_string()
+    } else if trimmed == "true" || trimmed == "false" {
+        "Boolean".to_string()
+    } else if trimmed.parse::<f64>().is_ok() {
+        "Number".to_string()
+    } else {
+        "Unknown".to_string()
+    }
+}
+
+/// 执行命令
+async fn execute_command(app: &mut App, client: &mut DoreaClient, cmd: &str) {
+    app.add_log("CMD", cmd);
+    
+    // 解析特殊命令
+    let parts: Vec<&str> = cmd.split_whitespace().collect();
+    if parts.is_empty() {
+        return;
+    }
+    
+    match parts[0] {
+        "select" if parts.len() >= 2 => {
+            let db = parts[1];
+            match client.select(db).await {
+                Ok(_) => {
+                    app.current_database = db.to_string();
+                    app.add_log("INFO", &format!("Switched to database: {}", db));
+                }
+                Err(e) => {
+                    app.add_log("ERROR", &format!("Failed: {:?}", e));
+                }
+            }
+        }
+        _ => {
+            // 执行通用命令
+            match client.execute(cmd).await {
+                Ok((state, data)) => {
+                    let result = String::from_utf8_lossy(&data).to_string();
+                    if state == NetPacketState::OK {
+                        app.add_log("INFO", &format!("OK: {}", if result.len() > 50 { &result[..50] } else { &result }));
+                    } else {
+                        app.add_log("ERROR", &result);
+                    }
+                }
+                Err(e) => {
+                    app.add_log("ERROR", &format!("Error: {:?}", e));
+                }
+            }
+        }
+    }
+}
+
+/// 绘制 UI
+fn ui(f: &mut Frame, app: &mut App) {
+    // 创建主布局
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(0)
+        .constraints([
+            Constraint::Length(1),  // 标题栏
+            Constraint::Length(1),  // Tab 栏
+            Constraint::Min(10),    // 主内容区
+            Constraint::Length(1),  // 状态栏
+        ])
+        .split(f.size());
+    
+    // 标题栏 - 提前创建 String 避免临时值问题
+    let port_str = app.port.to_string();
+    let title = Paragraph::new(Line::from(vec![
+        Span::styled(" Dorea CLI ", Style::default().fg(Color::Cyan).bold()),
+        Span::raw("v"),
+        Span::styled(DOREA_CLI_VERSION, Style::default().fg(Color::Green)),
+        Span::raw("  "),
+        Span::styled(&app.current_database, Style::default().fg(Color::Yellow).bold()),
+        Span::raw("@"),
+        Span::styled(&app.hostname, Style::default().fg(Color::White)),
+        Span::raw(":"),
+        Span::styled(&port_str, Style::default().fg(Color::White)),
+    ]));
+    f.render_widget(title, chunks[0]);
+    
+    // Tab 栏
+    let titles: Vec<Line> = TabId::titles()
+        .iter()
+        .enumerate()
+        .map(|(i, &title)| {
+            if i == app.current_tab as usize {
+                Line::from(Span::styled(
+                    format!("[{}]", title),
+                    Style::default().fg(Color::Cyan).bold(),
+                ))
+            } else {
+                Line::from(Span::styled(
+                    format!(" {} ", title),
+                    Style::default().fg(Color::DarkGray),
+                ))
+            }
+        })
+        .collect();
+    
+    let tabs = Tabs::new(titles);
+    f.render_widget(tabs, chunks[1]);
+    
+    // 主内容区
+    match app.current_tab {
+        TabId::Data => render_data_tab(f, app, chunks[2]),
+        TabId::Monitor => render_monitor_tab(f, app, chunks[2]),
+        TabId::Log => render_log_tab(f, app, chunks[2]),
+        TabId::Help => render_help_tab(f, app, chunks[2]),
+    }
+    
+    // 状态栏
+    let status = Paragraph::new(Line::from(vec![
+        Span::styled(" ", Style::default()),
+        Span::styled(&app.status_message, Style::default().fg(Color::DarkGray)),
+    ]));
+    f.render_widget(status, chunks[3]);
+    
+    // 命令输入框
+    if app.command_mode {
+        let area = centered_rect(60, 3, f.size());
+        f.render_widget(Clear, area);
+        
+        let input = Paragraph::new(Line::from(vec![
+            Span::styled(":", Style::default().fg(Color::Yellow).bold()),
+            Span::raw(&app.command_input),
+            Span::styled("▌", Style::default().fg(Color::Cyan)),
+        ]))
+        .block(Block::default().borders(Borders::ALL).title("Command"));
+        f.render_widget(input, area);
+    }
+}
+
+/// 渲染 Data Tab
+fn render_data_tab(f: &mut Frame, app: &mut App, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(20), Constraint::Min(40)])
+        .split(area);
+    
+    // 左侧：数据库列表
+    let db_items: Vec<ListItem> = app
+        .databases
+        .iter()
+        .enumerate()
+        .map(|(i, db)| {
+            let style = if i == app.selected_database && app.focus == Focus::DatabaseList {
+                Style::default().fg(Color::Yellow).bg(Color::DarkGray)
+            } else if i == app.selected_database {
+                Style::default().fg(Color::Yellow)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            ListItem::new(Line::from(Span::styled(format!("  {}", db), style)))
+        })
+        .collect();
+    
+    let db_list = List::new(db_items)
+        .block(Block::default()
+            .borders(Borders::ALL)
+            .title(" Databases ")
+            .title_style(Style::default().fg(Color::Cyan)));
+    f.render_widget(db_list, chunks[0]);
+    
+    // 右侧：键列表 + 值视图
+    let right_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(chunks[1]);
+    
+    // 键列表
+    let key_rows: Vec<Row> = app
+        .keys
+        .iter()
+        .enumerate()
+        .map(|(i, key)| {
+            let style = if i == app.selected_key && app.focus == Focus::KeyList {
+                Style::default().fg(Color::Yellow).bg(Color::DarkGray)
+            } else {
+                Style::default()
+            };
+            Row::new(vec![
+                Span::styled(&key.key, style.clone()),
+                Span::styled(&key.key_type, style.clone()),
+                Span::styled(&key.size, style.clone()),
+            ])
+        })
+        .collect();
+    
+    let key_table = Table::new(
+        key_rows,
+        [Constraint::Percentage(50), Constraint::Percentage(25), Constraint::Percentage(25)],
+    )
+    .header(
+        Row::new(vec![
+            Span::styled("KEY", Style::default().fg(Color::Cyan).bold()),
+            Span::styled("TYPE", Style::default().fg(Color::Cyan).bold()),
+            Span::styled("SIZE", Style::default().fg(Color::Cyan).bold()),
+        ])
+    )
+    .block(Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" Keys ({}) ", app.keys.len()))
+        .title_style(Style::default().fg(Color::Cyan)));
+    f.render_widget(key_table, right_chunks[0]);
+    
+    // 值视图
+    let value_title = if let Some(ref vtype) = app.current_value_type {
+        format!(" Value ({}) ", vtype)
+    } else {
+        " Value ".to_string()
+    };
+    
+    let mode_hint = match app.value_mode {
+        ValueViewMode::Tree => " [F2: Raw]",
+        ValueViewMode::Raw => " [F2: Tree]",
+    };
+    
+    let value_content = match &app.current_value {
+        Some(value) => value.clone(),
+        None => "(no value)".to_string(),
+    };
+    
+    let value_widget = Paragraph::new(value_content)
+        .block(Block::default()
+            .borders(Borders::ALL)
+            .title(value_title + mode_hint)
+            .title_style(Style::default().fg(Color::Cyan)));
+    f.render_widget(value_widget, right_chunks[1]);
+}
+
+/// 渲染 Monitor Tab
+fn render_monitor_tab(f: &mut Frame, app: &mut App, area: Rect) {
+    let text = vec![
+        Line::from("Monitor Tab - Coming Soon"),
+        Line::from(""),
+        Line::from("This tab will show:"),
+        Line::from("  - Server version"),
+        Line::from("  - Connection count"),
+        Line::from("  - Memory usage"),
+        Line::from("  - Index count"),
+        Line::from(""),
+        Line::from("Auto-refresh every 2 seconds"),
+    ];
+    
+    let paragraph = Paragraph::new(text)
+        .block(Block::default()
+            .borders(Borders::ALL)
+            .title(" Monitor ")
+            .title_style(Style::default().fg(Color::Cyan)));
+    f.render_widget(paragraph, area);
+}
+
+/// 渲染 Log Tab
+fn render_log_tab(f: &mut Frame, app: &mut App, area: Rect) {
+    let log_items: Vec<ListItem> = app
+        .logs
+        .iter()
+        .map(|log| {
+            let level_style = match log.level.as_str() {
+                "ERROR" => Style::default().fg(Color::Red),
+                "WARN" => Style::default().fg(Color::Yellow),
+                "INFO" => Style::default().fg(Color::Green),
+                "CMD" => Style::default().fg(Color::Cyan),
+                _ => Style::default().fg(Color::White),
+            };
+            
+            ListItem::new(Line::from(vec![
+                Span::styled(&log.timestamp, Style::default().fg(Color::DarkGray)),
+                Span::raw(" "),
+                Span::styled(format!("[{:^5}]", log.level), level_style),
+                Span::raw(" "),
+                Span::raw(&log.message),
+            ]))
+        })
+        .collect();
+    
+    let log_list = List::new(log_items)
+        .block(Block::default()
+            .borders(Borders::ALL)
+            .title(" Logs ")
+            .title_style(Style::default().fg(Color::Cyan)));
+    f.render_widget(log_list, area);
+}
+
+/// 渲染 Help Tab
+fn render_help_tab(f: &mut Frame, app: &mut App, area: Rect) {
+    let help_text = vec![
+        Line::from(Span::styled("Dorea CLI TUI - Key Bindings", Style::default().fg(Color::Cyan).bold())),
+        Line::from(""),
+        Line::from(Span::styled("Global", Style::default().fg(Color::Yellow).bold())),
+        Line::from("  q          Quit TUI"),
+        Line::from("  Tab        Switch tab"),
+        Line::from("  :          Command input"),
+        Line::from(""),
+        Line::from(Span::styled("Navigation (Vim Style)", Style::default().fg(Color::Yellow).bold())),
+        Line::from("  j/k        Move up/down"),
+        Line::from("  h/l        Switch panel (db → keys → value)"),
+        Line::from("  G          Jump to bottom"),
+        Line::from(""),
+        Line::from(Span::styled("Data Tab", Style::default().fg(Color::Yellow).bold())),
+        Line::from("  Enter      Select database"),
+        Line::from("  r          Refresh key list"),
+        Line::from("  F2         Toggle Tree/Raw mode"),
+        Line::from(""),
+        Line::from(Span::styled("Commands", Style::default().fg(Color::Yellow).bold())),
+        Line::from("  :select <db>    Switch database"),
+        Line::from("  :get <key>      Get value"),
+        Line::from("  :set <k> <v>    Set value"),
+        Line::from("  :q              Quit"),
+    ];
+    
+    let paragraph = Paragraph::new(help_text)
+        .block(Block::default()
+            .borders(Borders::ALL)
+            .title(" Help ")
+            .title_style(Style::default().fg(Color::Cyan)));
+    f.render_widget(paragraph, area);
+}
+
+/// 创建居中矩形
+fn centered_rect(percent_x: u16, height: u16, r: Rect) -> Rect {
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - height) / 2),
+            Constraint::Length(height),
+            Constraint::Percentage((100 - height) / 2),
+        ])
+        .split(r);
+    
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(popup_layout[1])[1]
+}

--- a/src/cli_tui.rs
+++ b/src/cli_tui.rs
@@ -68,7 +68,7 @@ enum Focus {
 /// 值显示模式
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum ValueViewMode {
-    Tree,
+    Pretty,
     Raw,
 }
 
@@ -99,7 +99,8 @@ pub struct App {
     // 命令输入
     command_input: String,
     command_mode: bool,
-    command_result: Option<(bool, String)>,
+    command_result: Option<(bool, String)>,  // (success, message)
+    command_result_time: Option<std::time::Instant>,  // 用于自动隐藏
     
     // 操作日志
     logs: Vec<LogEntry>,
@@ -148,7 +149,7 @@ impl App {
         Self {
             current_tab: TabId::Data,
             focus: Focus::KeyList,
-            value_mode: ValueViewMode::Tree,
+            value_mode: ValueViewMode::Pretty,
             hostname,
             port,
             current_database: "default".to_string(),
@@ -161,6 +162,7 @@ impl App {
             command_input: String::new(),
             command_mode: false,
             command_result: None,
+            command_result_time: None,
             logs: Vec::new(),
             monitor: MonitorData::default(),
             status_message: "Press j/k to navigate, h/l to switch panels, q to quit".to_string(),
@@ -347,11 +349,11 @@ async fn handle_data_tab_keys(
             // TODO: 搜索
             app.status_message = "Search: (not implemented yet)".to_string();
         }
+        // 切换 Pretty/Raw 模式
         KeyCode::F(2) => {
-            // 切换 Tree/Raw 模式
             app.value_mode = match app.value_mode {
-                ValueViewMode::Tree => ValueViewMode::Raw,
-                ValueViewMode::Raw => ValueViewMode::Tree,
+                ValueViewMode::Pretty => ValueViewMode::Raw,
+                ValueViewMode::Raw => ValueViewMode::Pretty,
             };
         }
         _ => {}
@@ -473,7 +475,7 @@ async fn load_key_value(app: &mut App, client: &mut DoreaClient, key: &str) {
             
             let value_type = infer_value_type(&raw_value);
             
-            // 格式化值（Tree 模式）
+            // 格式化值（Pretty 模式）
             let formatted_value = format_value(&raw_value, &value_type);
             
             app.current_value_raw = Some(raw_value.clone());
@@ -494,7 +496,7 @@ async fn load_key_value(app: &mut App, client: &mut DoreaClient, key: &str) {
     }
 }
 
-/// 格式化值（Tree 模式）- 真正的树形结构
+/// 格式化值（Pretty 模式）- 树形结构美化
 fn format_value(value: &str, value_type: &str) -> String {
     match value_type {
         "Dict" => format_dict_tree(value),
@@ -712,6 +714,11 @@ async fn execute_command(app: &mut App, client: &mut DoreaClient, cmd: &str) {
         return;
     }
     
+    let show_result = |app: &mut App, success: bool, msg: &str| {
+        app.command_result = Some((success, msg.to_string()));
+        app.command_result_time = Some(std::time::Instant::now());
+    };
+    
     match parts[0] {
         "select" if parts.len() >= 2 => {
             let db = parts[1];
@@ -722,13 +729,13 @@ async fn execute_command(app: &mut App, client: &mut DoreaClient, cmd: &str) {
                     app.selected_key = 0;
                     app.current_value = None;
                     app.current_value_raw = None;
-                    app.status_message = format!("✓ Switched to database: {}", db);
+                    show_result(app, true, &format!("Switched to database: {}", db));
                     app.add_log("INFO", &format!("Switched to database: {}", db));
                     // 切换数据库后刷新键列表
                     load_keys(app, client).await;
                 }
                 Err(e) => {
-                    app.status_message = format!("✗ Error: {:?}", e);
+                    show_result(app, false, &format!("Error: {:?}", e));
                     app.add_log("ERROR", &format!("Failed: {:?}", e));
                 }
             }
@@ -739,22 +746,22 @@ async fn execute_command(app: &mut App, client: &mut DoreaClient, cmd: &str) {
                 Ok((state, data)) => {
                     let result = String::from_utf8_lossy(&data).to_string();
                     if state == NetPacketState::OK {
-                        let preview = if result.len() > 50 { 
-                            format!("{}...", &result[..47])
+                        let preview = if result.len() > 100 { 
+                            format!("{}...", &result[..97])
                         } else { 
                             result.clone()
                         };
-                        app.status_message = format!("✓ {}", preview);
+                        show_result(app, true, &preview);
                         app.add_log("INFO", &format!("OK: {}", preview));
                         // 执行命令后自动刷新键列表（保留缓存）
                         load_keys(app, client).await;
                     } else {
-                        app.status_message = format!("✗ {}", result);
+                        show_result(app, false, &result);
                         app.add_log("ERROR", &result);
                     }
                 }
                 Err(e) => {
-                    app.status_message = format!("✗ Error: {:?}", e);
+                    show_result(app, false, &format!("Error: {:?}", e));
                     app.add_log("ERROR", &format!("Error: {:?}", e));
                 }
             }
@@ -841,6 +848,37 @@ fn ui(f: &mut Frame, app: &mut App) {
         .block(Block::default().borders(Borders::ALL).title("Command"));
         f.render_widget(input, area);
     }
+    
+    // 命令结果弹出窗口 (显示 3 秒后自动消失)
+    if let Some((success, ref msg)) = app.command_result {
+        if let Some(time) = app.command_result_time {
+            if time.elapsed().as_secs() < 3 {
+                let area = centered_rect(70, 3, f.size());
+                f.render_widget(Clear, area);
+                
+                let (icon, color) = if success {
+                    ("✓", Color::Green)
+                } else {
+                    ("✗", Color::Red)
+                };
+                
+                let result = Paragraph::new(Line::from(vec![
+                    Span::styled(format!("{} ", icon), Style::default().fg(color).bold()),
+                    Span::styled(msg, Style::default().fg(Color::White)),
+                ]))
+                .block(Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Result ")
+                    .title_style(Style::default().fg(color))
+                    .border_style(Style::default().fg(color)));
+                f.render_widget(result, area);
+            } else {
+                // 超时自动清除
+                app.command_result = None;
+                app.command_result_time = None;
+            }
+        }
+    }
 }
 
 /// 渲染 Data Tab
@@ -895,13 +933,13 @@ fn render_data_tab(f: &mut Frame, app: &mut App, area: Rect) {
     };
     
     let mode_hint = match app.value_mode {
-        ValueViewMode::Tree => " [F2: Raw]",
-        ValueViewMode::Raw => " [F2: Tree]",
+        ValueViewMode::Pretty => " [F2: Raw]",
+        ValueViewMode::Raw => " [F2: Pretty]",
     };
     
     // 根据模式选择显示的值
     let value_content = match app.value_mode {
-        ValueViewMode::Tree => match &app.current_value {
+        ValueViewMode::Pretty => match &app.current_value {
             Some(value) => value.clone(),
             None => "(no value)".to_string(),
         },
@@ -1080,25 +1118,30 @@ fn render_help_tab(f: &mut Frame, app: &mut App, area: Rect) {
         Line::from(Span::styled("Dorea CLI TUI - Key Bindings", Style::default().fg(Color::Cyan).bold())),
         Line::from(""),
         Line::from(Span::styled("Global", Style::default().fg(Color::Yellow).bold())),
-        Line::from("  q          Quit TUI"),
-        Line::from("  Tab        Switch tab"),
-        Line::from("  :          Command input"),
+        Line::from("  q              Quit TUI"),
+        Line::from("  Tab            Next tab"),
+        Line::from("  Shift+Tab      Previous tab"),
+        Line::from("  :              Command input"),
         Line::from(""),
-        Line::from(Span::styled("Navigation (Vim Style)", Style::default().fg(Color::Yellow).bold())),
-        Line::from("  j/k        Move up/down"),
-        Line::from("  h/l        Switch panel (db → keys → value)"),
-        Line::from("  G          Jump to bottom"),
+        Line::from(Span::styled("Navigation", Style::default().fg(Color::Yellow).bold())),
+        Line::from("  j / ↓          Move down"),
+        Line::from("  k / ↑          Move up"),
+        Line::from("  h / ←          Previous panel"),
+        Line::from("  l / →          Next panel"),
+        Line::from("  G              Jump to bottom"),
+        Line::from("  g              Jump to top"),
         Line::from(""),
         Line::from(Span::styled("Data Tab", Style::default().fg(Color::Yellow).bold())),
-        Line::from("  Enter      Select database"),
-        Line::from("  r          Refresh key list"),
-        Line::from("  F2         Toggle Tree/Raw mode"),
+        Line::from("  Enter          Load selected key value"),
+        Line::from("  r              Refresh key list"),
+        Line::from("  F2             Toggle Pretty/Raw mode"),
         Line::from(""),
         Line::from(Span::styled("Commands", Style::default().fg(Color::Yellow).bold())),
-        Line::from("  :select <db>    Switch database"),
-        Line::from("  :get <key>      Get value"),
-        Line::from("  :set <k> <v>    Set value"),
-        Line::from("  :q              Quit"),
+        Line::from("  :select <db>   Switch database"),
+        Line::from("  :get <key>     Get value"),
+        Line::from("  :set <k> <v>   Set value"),
+        Line::from("  :del <key>     Delete key"),
+        Line::from("  :q             Quit"),
     ];
     
     let paragraph = Paragraph::new(help_text)

--- a/src/cli_tui.rs
+++ b/src/cli_tui.rs
@@ -503,7 +503,9 @@ fn format_value(value: &str, value_type: &str) -> String {
 /// 推断值类型
 fn infer_value_type(value: &str) -> String {
     let trimmed = value.trim();
-    if trimmed.starts_with('{') && trimmed.ends_with('}') {
+    if trimmed.starts_with("binary!(") {
+        "Binary".to_string()
+    } else if trimmed.starts_with('{') && trimmed.ends_with('}') {
         "Dict".to_string()
     } else if trimmed.starts_with('[') && trimmed.ends_with(']') {
         "List".to_string()
@@ -516,7 +518,7 @@ fn infer_value_type(value: &str) -> String {
     } else if trimmed.parse::<f64>().is_ok() {
         "Number".to_string()
     } else {
-        "Unknown".to_string()
+        "String".to_string()
     }
 }
 

--- a/src/cli_tui.rs
+++ b/src/cli_tui.rs
@@ -417,9 +417,9 @@ async fn load_keys(app: &mut App, client: &mut DoreaClient) {
             
             app.status_message = format!("Loaded {} keys", app.keys.len());
             
-            // 加载第一个键的值 - 先 clone key 避免借用冲突
-            let first_key = app.keys.first().map(|k| k.key.clone());
-            if let Some(key) = first_key {
+            // 加载当前选中键的值 - 先 clone key 避免借用冲突
+            let selected_key = app.keys.get(app.selected_key).map(|k| k.key.clone());
+            if let Some(key) = selected_key {
                 load_key_value(app, client, &key).await;
             }
         }
@@ -494,18 +494,115 @@ async fn load_key_value(app: &mut App, client: &mut DoreaClient, key: &str) {
     }
 }
 
-/// 格式化值（Tree 模式）
+/// 格式化值（Tree 模式）- 真正的树形结构
 fn format_value(value: &str, value_type: &str) -> String {
     match value_type {
-        "Dict" | "List" => {
-            // 尝试 JSON 格式化
-            if let Ok(json) = serde_json::from_str::<serde_json::Value>(value) {
-                serde_json::to_string_pretty(&json).unwrap_or_else(|_| value.to_string())
+        "Dict" => format_dict_tree(value),
+        "List" => format_list_tree(value),
+        _ => value.to_string(),
+    }
+}
+
+/// 格式化 Dict 为树形结构
+fn format_dict_tree(value: &str) -> String {
+    // 尝试解析为 JSON
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(value) {
+        if let serde_json::Value::Object(map) = json {
+            let mut result = String::new();
+            let keys: Vec<_> = map.keys().collect();
+            
+            for (i, key) in keys.iter().enumerate() {
+                let is_last = i == keys.len() - 1;
+                let prefix = if is_last { "└── " } else { "├── " };
+                
+                if let Some(val) = map.get(*key) {
+                    result.push_str(&format!("{}{}: ", prefix, key));
+                    result.push_str(&format_json_value(val, if is_last { "    " } else { "│   " }));
+                    result.push('\n');
+                }
+            }
+            
+            return result.trim_end().to_string();
+        }
+    }
+    
+    // 解析失败，返回原始值
+    value.to_string()
+}
+
+/// 格式化 List 为树形结构
+fn format_list_tree(value: &str) -> String {
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(value) {
+        if let serde_json::Value::Array(arr) = json {
+            let mut result = String::new();
+            
+            for (i, item) in arr.iter().enumerate() {
+                let is_last = i == arr.len() - 1;
+                let prefix = if is_last { "└── " } else { "├── " };
+                let indent = if is_last { "    " } else { "│   " };
+                
+                result.push_str(&format!("{}[{}] ", prefix, i));
+                result.push_str(&format_json_value(item, indent));
+                result.push('\n');
+            }
+            
+            return result.trim_end().to_string();
+        }
+    }
+    
+    value.to_string()
+}
+
+/// 格式化 JSON 值（递归）
+fn format_json_value(value: &serde_json::Value, indent: &str) -> String {
+    match value {
+        serde_json::Value::Object(map) => {
+            if map.is_empty() {
+                "{}".to_string()
             } else {
-                value.to_string()
+                let mut result = "{\n".to_string();
+                let keys: Vec<_> = map.keys().collect();
+                
+                for (i, key) in keys.iter().enumerate() {
+                    let is_last = i == keys.len() - 1;
+                    let prefix = if is_last { "└── " } else { "├── " };
+                    let next_indent = if is_last { "    " } else { "│   " };
+                    
+                    if let Some(val) = map.get(*key) {
+                        result.push_str(&format!("{}{}{}: ", indent, prefix, key));
+                        result.push_str(&format_json_value(val, &format!("{}{}", indent, next_indent)));
+                        result.push('\n');
+                    }
+                }
+                
+                result.push_str(&format!("{}}}", &indent[..indent.len().saturating_sub(4)]));
+                result
             }
         }
-        _ => value.to_string(),
+        serde_json::Value::Array(arr) => {
+            if arr.is_empty() {
+                "[]".to_string()
+            } else {
+                let mut result = "[\n".to_string();
+                
+                for (i, item) in arr.iter().enumerate() {
+                    let is_last = i == arr.len() - 1;
+                    let prefix = if is_last { "└── " } else { "├── " };
+                    let next_indent = if is_last { "    " } else { "│   " };
+                    
+                    result.push_str(&format!("{}{}[{}] ", indent, prefix, i));
+                    result.push_str(&format_json_value(item, &format!("{}{}", indent, next_indent)));
+                    result.push('\n');
+                }
+                
+                result.push_str(&format!("{}]", &indent[..indent.len().saturating_sub(4)]));
+                result
+            }
+        }
+        serde_json::Value::String(s) => format!("\"{}\"", s),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Null => "null".to_string(),
     }
 }
 

--- a/src/cli_tui.rs
+++ b/src/cli_tui.rs
@@ -293,16 +293,30 @@ async fn handle_key_event(
             app.should_quit = true;
         }
         KeyCode::Tab => {
+            let prev_tab = app.current_tab;
             app.current_tab = app.current_tab.next();
+            // 切换到 Monitor Tab 时自动刷新
+            if prev_tab != TabId::Monitor && app.current_tab == TabId::Monitor {
+                load_monitor_data(app, client).await;
+            }
         }
         KeyCode::BackTab => {
+            let prev_tab = app.current_tab;
             app.current_tab = app.current_tab.prev();
+            // 切换到 Monitor Tab 时自动刷新
+            if prev_tab != TabId::Monitor && app.current_tab == TabId::Monitor {
+                load_monitor_data(app, client).await;
+            }
         }
         KeyCode::Char('g') if key.modifiers.contains(KeyModifiers::NONE) => {
             // gg = 跳转到顶部（需要两次 g）
         }
         KeyCode::Char('t') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            let prev_tab = app.current_tab;
             app.current_tab = app.current_tab.next();
+            if prev_tab != TabId::Monitor && app.current_tab == TabId::Monitor {
+                load_monitor_data(app, client).await;
+            }
         }
         KeyCode::Char(':') => {
             app.command_mode = true;
@@ -520,8 +534,21 @@ async fn load_key_value(app: &mut App, client: &mut DoreaClient, key: &str) {
             app.current_value_raw = Some(raw_value.clone());
             app.current_value = Some(formatted_value);
             app.current_value_type = Some(value_type.clone());
-            app.value_tree = value_tree;
-            app.expand_state = ExpandState::default();  // 重置展开状态
+            app.value_tree = value_tree.clone();
+            
+            // 智能展开：第一层少于30项自动展开
+            let mut expand_state = ExpandState::default();
+            if let Some(tree) = &value_tree {
+                let should_expand = match tree {
+                    ValueNode::Object(map) => map.len() <= 30,
+                    ValueNode::Array(arr) => arr.len() <= 30,
+                    _ => false,
+                };
+                if should_expand {
+                    expand_state.expanded.insert("".to_string());
+                }
+            }
+            app.expand_state = expand_state;
             
             // 更新键列表中的类型
             if let Some(key_info) = app.keys.iter_mut().find(|k| k.key == key) {
@@ -1253,30 +1280,31 @@ fn render_help_tab(f: &mut Frame, app: &mut App, area: Rect) {
         Line::from(Span::styled("Dorea CLI TUI - Key Bindings", Style::default().fg(Color::Cyan).bold())),
         Line::from(""),
         Line::from(Span::styled("Global", Style::default().fg(Color::Yellow).bold())),
-        Line::from("  q              Quit TUI"),
-        Line::from("  Tab            Next tab"),
-        Line::from("  Shift+Tab      Previous tab"),
-        Line::from("  :              Command input"),
+        Line::from("  q                     Quit TUI"),
+        Line::from("  Tab / Shift+Tab       Next / Previous tab"),
+        Line::from("  :                     Command input"),
         Line::from(""),
         Line::from(Span::styled("Navigation", Style::default().fg(Color::Yellow).bold())),
-        Line::from("  j / ↓          Move down"),
-        Line::from("  k / ↑          Move up"),
-        Line::from("  h / ←          Previous panel"),
-        Line::from("  l / →          Next panel"),
-        Line::from("  G              Jump to bottom"),
-        Line::from("  g              Jump to top"),
+        Line::from("  j / ↓                 Move down"),
+        Line::from("  k / ↑                 Move up"),
+        Line::from("  h / ←                 Previous panel"),
+        Line::from("  l / →                 Next panel"),
+        Line::from("  G                     Jump to bottom"),
+        Line::from("  g                     Jump to top"),
         Line::from(""),
         Line::from(Span::styled("Data Tab", Style::default().fg(Color::Yellow).bold())),
-        Line::from("  Enter          Load selected key value"),
-        Line::from("  r              Refresh key list"),
-        Line::from("  F2             Toggle Pretty/Raw mode"),
+        Line::from("  Enter                 Expand/Collapse value tree"),
+        Line::from("  r                     Refresh key list"),
+        Line::from("  F2                    Toggle Pretty/Raw mode"),
+        Line::from(""),
+        Line::from(Span::styled("Monitor Tab", Style::default().fg(Color::Yellow).bold())),
+        Line::from("  r                     Refresh monitor data"),
         Line::from(""),
         Line::from(Span::styled("Commands", Style::default().fg(Color::Yellow).bold())),
-        Line::from("  :select <db>   Switch database"),
-        Line::from("  :get <key>     Get value"),
-        Line::from("  :set <k> <v>   Set value"),
-        Line::from("  :del <key>     Delete key"),
-        Line::from("  :q             Quit"),
+        Line::from("  select <db>           Switch database"),
+        Line::from("  get <key>             Get value"),
+        Line::from("  set <k> <v>           Set value"),
+        Line::from("  del <key>             Delete key"),
     ];
     
     let paragraph = Paragraph::new(help_text)

--- a/src/cli_tui.rs
+++ b/src/cli_tui.rs
@@ -108,6 +108,9 @@ pub struct App {
     // 操作日志
     logs: Vec<LogEntry>,
     
+    // Monitor 数据
+    monitor: MonitorData,
+    
     // 状态消息
     status_message: String,
     
@@ -122,6 +125,18 @@ struct KeyInfo {
     key_type: String,
     size: String,
     ttl: String,
+}
+
+/// Monitor 数据
+#[derive(Debug, Clone, Default)]
+struct MonitorData {
+    server_version: String,
+    uptime: String,
+    connected_clients: String,
+    total_keys: String,
+    memory_used: String,
+    total_commands: String,
+    last_updated: String,
 }
 
 /// 日志条目
@@ -152,6 +167,7 @@ impl App {
             command_mode: false,
             command_result: None,
             logs: Vec::new(),
+            monitor: MonitorData::default(),
             status_message: "Press j/k to navigate, h/l to switch panels, q to quit".to_string(),
             should_quit: false,
         }
@@ -270,7 +286,7 @@ async fn handle_key_event(
             // Tab 特定快捷键
             match app.current_tab {
                 TabId::Data => handle_data_tab_keys(key, app, client).await?,
-                TabId::Monitor => handle_monitor_tab_keys(key, app).await?,
+                TabId::Monitor => handle_monitor_tab_keys(key, app, client).await?,
                 TabId::Log => handle_log_tab_keys(key, app).await?,
                 TabId::Help => handle_help_tab_keys(key, app).await?,
             }
@@ -287,8 +303,8 @@ async fn handle_data_tab_keys(
     client: &mut DoreaClient,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match key.code {
-        // 导航
-        KeyCode::Char('j') => {
+        // 导航 - 支持 j/k 和 上下方向键
+        KeyCode::Char('j') | KeyCode::Down => {
             match app.focus {
                 Focus::DatabaseList => {
                     if app.selected_database < app.databases.len() - 1 {
@@ -308,7 +324,7 @@ async fn handle_data_tab_keys(
                 _ => {}
             }
         }
-        KeyCode::Char('k') => {
+        KeyCode::Char('k') | KeyCode::Up => {
             match app.focus {
                 Focus::DatabaseList => {
                     if app.selected_database > 0 {
@@ -327,14 +343,15 @@ async fn handle_data_tab_keys(
                 _ => {}
             }
         }
-        KeyCode::Char('h') => {
+        // 支持 h/l 和 左右方向键
+        KeyCode::Char('h') | KeyCode::Left => {
             match app.focus {
                 Focus::KeyList => app.focus = Focus::DatabaseList,
                 Focus::ValueView => app.focus = Focus::KeyList,
                 _ => {}
             }
         }
-        KeyCode::Char('l') => {
+        KeyCode::Char('l') | KeyCode::Right => {
             match app.focus {
                 Focus::DatabaseList => app.focus = Focus::KeyList,
                 Focus::KeyList => app.focus = Focus::ValueView,
@@ -394,9 +411,11 @@ async fn handle_data_tab_keys(
 async fn handle_monitor_tab_keys(
     key: event::KeyEvent,
     app: &mut App,
+    client: &mut DoreaClient,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match key.code {
         KeyCode::Char('r') => {
+            load_monitor_data(app, client).await;
             app.add_log("INFO", "Refreshed monitor data");
         }
         _ => {}
@@ -481,9 +500,15 @@ async fn load_key_value(app: &mut App, client: &mut DoreaClient, key: &str) {
     match client.execute(&command).await {
         Ok((state, data)) if state == NetPacketState::OK => {
             let value = String::from_utf8_lossy(&data).to_string();
+            let value_type = infer_value_type(&value);
             app.current_value = Some(value);
-            // 尝试推断类型
-            app.current_value_type = Some(infer_value_type(&app.current_value.as_ref().unwrap()));
+            app.current_value_type = Some(value_type.clone());
+            
+            // 更新键列表中的类型
+            if let Some(key_info) = app.keys.iter_mut().find(|k| k.key == key) {
+                key_info.key_type = value_type;
+                key_info.size = format!("{}B", app.current_value.as_ref().unwrap().len());
+            }
         }
         _ => {
             app.current_value = Some("(error loading value)".to_string());
@@ -509,6 +534,91 @@ fn infer_value_type(value: &str) -> String {
         "Number".to_string()
     } else {
         "Unknown".to_string()
+    }
+}
+
+/// 加载 Monitor 数据
+async fn load_monitor_data(app: &mut App, client: &mut DoreaClient) {
+    // 获取服务器信息
+    if let Ok((state, data)) = client.execute("info server").await {
+        if state == NetPacketState::OK {
+            let info = String::from_utf8_lossy(&data).to_string();
+            // 解析服务器信息
+            for line in info.lines() {
+                if let Some(version) = line.strip_prefix("version:") {
+                    app.monitor.server_version = version.trim().to_string();
+                } else if let Some(uptime) = line.strip_prefix("uptime:") {
+                    app.monitor.uptime = format_seconds(uptime.trim().parse().unwrap_or(0));
+                }
+            }
+        }
+    }
+    
+    // 获取客户端连接数
+    if let Ok((state, data)) = client.execute("info client").await {
+        if state == NetPacketState::OK {
+            let info = String::from_utf8_lossy(&data).to_string();
+            for line in info.lines() {
+                if let Some(count) = line.strip_prefix("connected:") {
+                    app.monitor.connected_clients = count.trim().to_string();
+                }
+            }
+        }
+    }
+    
+    // 获取键数量
+    if let Ok((state, data)) = client.execute("info keys").await {
+        if state == NetPacketState::OK {
+            let result = String::from_utf8_lossy(&data).to_string();
+            // 解析键列表 ["key1", "key2", ...]
+            if result.starts_with('[') {
+                let count = result.matches(',').count().max(0) + if result.contains('"') { 1 } else { 0 };
+                app.monitor.total_keys = count.to_string();
+            }
+        }
+    }
+    
+    // 获取内存使用
+    if let Ok((state, data)) = client.execute("info memory").await {
+        if state == NetPacketState::OK {
+            let info = String::from_utf8_lossy(&data).to_string();
+            for line in info.lines() {
+                if let Some(memory) = line.strip_prefix("used:") {
+                    app.monitor.memory_used = format_bytes(memory.trim().parse().unwrap_or(0));
+                }
+            }
+        }
+    }
+    
+    // 更新时间
+    app.monitor.last_updated = chrono::Local::now().format("%H:%M:%S").to_string();
+}
+
+/// 格式化秒数为可读时间
+fn format_seconds(seconds: u64) -> String {
+    if seconds < 60 {
+        format!("{}s", seconds)
+    } else if seconds < 3600 {
+        format!("{}m {}s", seconds / 60, seconds % 60)
+    } else {
+        format!("{}h {}m", seconds / 3600, (seconds % 3600) / 60)
+    }
+}
+
+/// 格式化字节数为可读大小
+fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+    
+    if bytes >= GB {
+        format!("{:.2} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.2} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.2} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} B", bytes)
     }
 }
 
@@ -735,24 +845,66 @@ fn render_data_tab(f: &mut Frame, app: &mut App, area: Rect) {
 
 /// 渲染 Monitor Tab
 fn render_monitor_tab(f: &mut Frame, app: &mut App, area: Rect) {
-    let text = vec![
-        Line::from("Monitor Tab - Coming Soon"),
+    // 使用两列布局
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(area);
+    
+    // 左侧 - 服务器信息
+    let server_info = vec![
+        Line::from(vec![
+            Span::styled("Server Version:  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(&app.monitor.server_version, Style::default().fg(Color::White)),
+        ]),
         Line::from(""),
-        Line::from("This tab will show:"),
-        Line::from("  - Server version"),
-        Line::from("  - Connection count"),
-        Line::from("  - Memory usage"),
-        Line::from("  - Index count"),
+        Line::from(vec![
+            Span::styled("Uptime:          ", Style::default().fg(Color::DarkGray)),
+            Span::styled(&app.monitor.uptime, Style::default().fg(Color::White)),
+        ]),
+        Line::from(vec![
+            Span::styled("Connected:       ", Style::default().fg(Color::DarkGray)),
+            Span::styled(&app.monitor.connected_clients, Style::default().fg(Color::Green)),
+        ]),
         Line::from(""),
-        Line::from("Auto-refresh every 2 seconds"),
+        Line::from(vec![
+            Span::styled("Last Updated:    ", Style::default().fg(Color::DarkGray)),
+            Span::styled(&app.monitor.last_updated, Style::default().fg(Color::Yellow)),
+        ]),
     ];
     
-    let paragraph = Paragraph::new(text)
+    let left_panel = Paragraph::new(server_info)
         .block(Block::default()
             .borders(Borders::ALL)
-            .title(" Monitor ")
+            .title(" Server Info ")
             .title_style(Style::default().fg(Color::Cyan)));
-    f.render_widget(paragraph, area);
+    f.render_widget(left_panel, chunks[0]);
+    
+    // 右侧 - 数据统计
+    let data_stats = vec![
+        Line::from(vec![
+            Span::styled("Total Keys:      ", Style::default().fg(Color::DarkGray)),
+            Span::styled(&app.monitor.total_keys, Style::default().fg(Color::White)),
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Memory Used:     ", Style::default().fg(Color::DarkGray)),
+            Span::styled(&app.monitor.memory_used, Style::default().fg(Color::Magenta)),
+        ]),
+        Line::from(vec![
+            Span::styled("Total Commands:  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(&app.monitor.total_commands, Style::default().fg(Color::White)),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled("Press r to refresh", Style::default().fg(Color::DarkGray))),
+    ];
+    
+    let right_panel = Paragraph::new(data_stats)
+        .block(Block::default()
+            .borders(Borders::ALL)
+            .title(" Statistics ")
+            .title_style(Style::default().fg(Color::Cyan)));
+    f.render_widget(right_panel, chunks[1]);
 }
 
 /// 渲染 Log Tab

--- a/src/cli_tui.rs
+++ b/src/cli_tui.rs
@@ -93,6 +93,7 @@ pub struct App {
     
     // 当前值
     current_value: Option<String>,
+    current_value_raw: Option<String>,
     current_value_type: Option<String>,
     
     // 命令输入
@@ -155,6 +156,7 @@ impl App {
             selected_key: 0,
             key_scroll_offset: 0,
             current_value: None,
+            current_value_raw: None,
             current_value_type: None,
             command_input: String::new(),
             command_mode: false,
@@ -193,8 +195,9 @@ pub async fn run_tui(client: DoreaClient, hostname: String, port: u16) -> Result
     let mut app = App::new(hostname, port);
     let mut client = client;
     
-    // 初始加载数据库列表
+    // 初始加载数据
     app.add_log("INFO", "Connected to server");
+    load_keys(&mut app, &mut client).await;
     
     // 主循环
     loop {
@@ -264,6 +267,9 @@ async fn handle_key_event(
         }
         KeyCode::Tab => {
             app.current_tab = app.current_tab.next();
+        }
+        KeyCode::BackTab => {
+            app.current_tab = app.current_tab.prev();
         }
         KeyCode::Char('g') if key.modifiers.contains(KeyModifiers::NONE) => {
             // gg = 跳转到顶部（需要两次 g）
@@ -446,21 +452,42 @@ async fn load_key_value(app: &mut App, client: &mut DoreaClient, key: &str) {
     let command = format!("get {}", key);
     match client.execute(&command).await {
         Ok((state, data)) if state == NetPacketState::OK => {
-            let value = String::from_utf8_lossy(&data).to_string();
-            let value_type = infer_value_type(&value);
-            app.current_value = Some(value);
+            let raw_value = String::from_utf8_lossy(&data).to_string();
+            let value_type = infer_value_type(&raw_value);
+            
+            // 格式化值（Tree 模式）
+            let formatted_value = format_value(&raw_value, &value_type);
+            
+            app.current_value_raw = Some(raw_value);
+            app.current_value = Some(formatted_value);
             app.current_value_type = Some(value_type.clone());
             
             // 更新键列表中的类型
             if let Some(key_info) = app.keys.iter_mut().find(|k| k.key == key) {
                 key_info.key_type = value_type;
-                key_info.size = format!("{}B", app.current_value.as_ref().unwrap().len());
+                key_info.size = format!("{}B", app.current_value_raw.as_ref().unwrap().len());
             }
         }
         _ => {
             app.current_value = Some("(error loading value)".to_string());
+            app.current_value_raw = None;
             app.current_value_type = None;
         }
+    }
+}
+
+/// 格式化值（Tree 模式）
+fn format_value(value: &str, value_type: &str) -> String {
+    match value_type {
+        "Dict" | "List" => {
+            // 尝试 JSON 格式化
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(value) {
+                serde_json::to_string_pretty(&json).unwrap_or_else(|_| value.to_string())
+            } else {
+                value.to_string()
+            }
+        }
+        _ => value.to_string(),
     }
 }
 
@@ -751,9 +778,16 @@ fn render_data_tab(f: &mut Frame, app: &mut App, area: Rect) {
         ValueViewMode::Raw => " [F2: Tree]",
     };
     
-    let value_content = match &app.current_value {
-        Some(value) => value.clone(),
-        None => "(no value)".to_string(),
+    // 根据模式选择显示的值
+    let value_content = match app.value_mode {
+        ValueViewMode::Tree => match &app.current_value {
+            Some(value) => value.clone(),
+            None => "(no value)".to_string(),
+        },
+        ValueViewMode::Raw => match &app.current_value_raw {
+            Some(value) => value.clone(),
+            None => "(no value)".to_string(),
+        },
     };
     
     let value_widget = Paragraph::new(value_content)

--- a/src/cli_tui.rs
+++ b/src/cli_tui.rs
@@ -406,8 +406,15 @@ async fn load_keys(app: &mut App, client: &mut DoreaClient) {
     match client.execute("info keys").await {
         Ok((state, data)) if state == NetPacketState::OK => {
             let result = String::from_utf8_lossy(&data).to_string();
-            // 解析键列表 ["key1", "key2", ...]
-            app.keys = parse_key_list(&result);
+            // 解析键列表，保留已有 key 的缓存
+            let old_keys = std::mem::take(&mut app.keys);
+            app.keys = parse_key_list(&result, &old_keys);
+            
+            // 尝试保持选中状态
+            if app.selected_key >= app.keys.len() {
+                app.selected_key = app.keys.len().saturating_sub(1);
+            }
+            
             app.status_message = format!("Loaded {} keys", app.keys.len());
             
             // 加载第一个键的值 - 先 clone key 避免借用冲突
@@ -423,8 +430,8 @@ async fn load_keys(app: &mut App, client: &mut DoreaClient) {
     }
 }
 
-/// 解析键列表
-fn parse_key_list(data: &str) -> Vec<KeyInfo> {
+/// 解析键列表，保留已有 key 的缓存
+fn parse_key_list(data: &str, cached_keys: &[KeyInfo]) -> Vec<KeyInfo> {
     let mut keys = Vec::new();
     
     // 简单解析 JSON 数组
@@ -434,11 +441,13 @@ fn parse_key_list(data: &str) -> Vec<KeyInfo> {
         for item in content.split(',') {
             let key = item.trim().trim_matches('"').to_string();
             if !key.is_empty() {
+                // 查找缓存
+                let cached = cached_keys.iter().find(|k| k.key == key);
                 keys.push(KeyInfo {
                     key: key.clone(),
-                    key_type: "-".to_string(),  // 未加载时显示 "-"
-                    size: "-".to_string(),
-                    ttl: "-".to_string(),
+                    key_type: cached.map(|k| k.key_type.clone()).unwrap_or_else(|| "-".to_string()),
+                    size: cached.map(|k| k.size.clone()).unwrap_or_else(|| "-".to_string()),
+                    ttl: cached.map(|k| k.ttl.clone()).unwrap_or_else(|| "-".to_string()),
                 });
             }
         }
@@ -601,8 +610,14 @@ async fn execute_command(app: &mut App, client: &mut DoreaClient, cmd: &str) {
             match client.select(db).await {
                 Ok(_) => {
                     app.current_database = db.to_string();
+                    app.keys.clear();  // 清空缓存
+                    app.selected_key = 0;
+                    app.current_value = None;
+                    app.current_value_raw = None;
                     app.status_message = format!("✓ Switched to database: {}", db);
                     app.add_log("INFO", &format!("Switched to database: {}", db));
+                    // 切换数据库后刷新键列表
+                    load_keys(app, client).await;
                 }
                 Err(e) => {
                     app.status_message = format!("✗ Error: {:?}", e);
@@ -623,10 +638,8 @@ async fn execute_command(app: &mut App, client: &mut DoreaClient, cmd: &str) {
                         };
                         app.status_message = format!("✓ {}", preview);
                         app.add_log("INFO", &format!("OK: {}", preview));
-                        // 如果是 keys 相关命令，刷新键列表
-                        if cmd.starts_with("set ") || cmd.starts_with("delete ") {
-                            // 可选：自动刷新键列表
-                        }
+                        // 执行命令后自动刷新键列表（保留缓存）
+                        load_keys(app, client).await;
                     } else {
                         app.status_message = format!("✗ {}", result);
                         app.add_log("ERROR", &result);


### PR DESCRIPTION
## Summary

新增 TUI (Terminal User Interface) 模式，提供可视化的数据浏览功能。

## Features

### TUI 模式
- 通过 `dorea-cli tui` 命令或 REPL 中输入 `tui` 启动
- Tab 切换界面：Data / Monitor / Log / Help

### Data Tab
- 两列布局（键列表 | 值视图）
- Vim 风格导航 (`j`/`k`/`h`/`l`) + 方向键支持
- **Pretty 模式**：组件化值展示，支持 Dict/List/Tuple 展开折叠
- 语法高亮：String 绿色、Number 黄色、Boolean 紫色
- 智能展开：第一层子项 ≤30 时自动展开
- `F2` 切换 Pretty/Raw 模式

### Monitor Tab
- 显示服务器版本、运行时间、连接数、索引数
- 切换到 Tab 时自动刷新

### Log Tab
- 记录操作日志

### 交互
- 按 `:` 进入命令模式
- 执行结果以居中弹窗显示，支持 ESC 关闭
- `r` 刷新、`Enter` 展开/折叠、`q` 退出

## Test Plan

- [x] `cargo build --release --features client` 编译通过
- [x] `dorea-cli tui` 正常启动
- [x] Tab 切换正常
- [x] 键导航正常
- [x] Pretty 模式展开/折叠正常
- [x] Monitor 数据加载正常
- [x] 命令执行弹窗正常

## Stats

- 5 files changed
- 1861 insertions(+), 10 deletions(-)
- 新增 `src/cli_tui.rs` (1348 行)