### PR TITLE
fix: panic on UTF-8 string slice in process_response_body

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -170,8 +170,8 @@ async fn process_response_body(
 ) -> Vec<u8> {
     match String::from_utf8_lossy(res_body).to_string().as_str() {
         "@[SERVER_STARTUP_TIME]" => startup_time.to_string().as_bytes().to_vec(),
-        val if val.len() > 14 && &val[0..14] == "@[PRELOAD_DB]:" => {
-            let db_name = String::from(&val[14..]);
+        val if val.starts_with("@[PRELOAD_DB]:") => {
+            let db_name = val[14..].to_string();
             let tmp_db_manager = database_manager.clone();
             let db_config = config.database.clone();
             tokio::spawn(async move {


### PR DESCRIPTION
## Bug Description

When storing and retrieving values containing 5+ multi-byte UTF-8 characters (e.g., Japanese), the `GET` command caused a panic:

```
thread 'tokio-runtime-worker' panicked at src/handle.rs:182:38:
end byte index 14 is not a char boundary; it is inside 'ス' (bytes 13..16 of string)
```

## Root Cause

In `process_response_body()`, the code used byte-based string slicing:

```rust
val if val.len() > 14 && &val[0..14] == "@[PRELOAD_DB]:" => {
```

This slices at byte index 14, which may fall in the middle of a multi-byte UTF-8 character.

## Reproduction

```bash
dorea-cli run 'set test "日本語テスト"'   # 5 Japanese chars = 20 bytes
dorea-cli run 'get test'                  # Panic!
```

## Fix

Changed to use `starts_with()` which handles UTF-8 boundaries correctly:

```rust
val if val.starts_with("@[PRELOAD_DB]:") => {
```

## Testing

- ✅ `日本語テスト` (5 Japanese chars)
- ✅ `あいうえおかきくけこ` (10 Japanese chars)
- ✅ `Hello 世界 🌍` (mixed)
- ✅ ASCII strings (no regression)